### PR TITLE
[NOJIRA]Updating chart-dir to canso-data-plane from charts/

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.5.0
+        with:
+          charts_dir: canso-data-plane
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true


### PR DESCRIPTION
### Description

Updating charts-dir in helm-relase action in github workflow.

ref - [https://github.com/helm/chart-releaser-action](https://github.com/helm/chart-releaser-action?tab=readme-ov-file#example-workflow:~:text=A%20GitHub%20repo%20containing%20a%20directory%20with%20your%20Helm%20charts%20(default%20is%20a%20folder%20named%20/charts%2C%20if%20you%20want%20to%20maintain%20your%20charts%20in%20a%20different%20directory%2C%20you%20must%20include%20a%20charts_dir%20input%20in%20the%20workflow).)