### PR TITLE
[NOJIRA] Adding README docs for karpenter, online-feature-service and worflow-orchestrator

### DIFF
--- a/canso-data-plane/canso-karpenter/README.md
+++ b/canso-data-plane/canso-karpenter/README.md
@@ -1,1 +1,97 @@
 ## Parameters
+
+### karpenter.serviceAccount Service account configuration
+
+| Name                                   | Description                                           | Value       |
+| -------------------------------------- | ----------------------------------------------------- | ----------- |
+| `karpenter.serviceAccount.create`      | Specifies whether a ServiceAccount should be created. | `true`      |
+| `karpenter.serviceAccount.name`        | The name of the ServiceAccount to use.                | `karpenter` |
+| `karpenter.serviceAccount.annotations` | Additional annotations for the ServiceAccount.        | `{}`        |
+| `karpenter.additionalClusterRoleRules` | Additional rules to add into the ClusterRole.         | `[]`        |
+
+### karpenter.serviceMonitor Service monitor configuration
+
+| Name                                        | Description                                                | Value   |
+| ------------------------------------------- | ---------------------------------------------------------- | ------- |
+| `karpenter.serviceMonitor.enabled`          | Specifies whether a ServiceMonitor should be created.      | `false` |
+| `karpenter.serviceMonitor.additionalLabels` | Additional labels for the ServiceMonitor.                  | `{}`    |
+| `karpenter.serviceMonitor.endpointConfig`   | Endpoint configuration for the ServiceMonitor.             | `{}`    |
+| `karpenter.replicas`                        | Number of replicas for the Karpenter controller.           | `2`     |
+| `karpenter.revisionHistoryLimit`            | The number of old ReplicaSets to retain to allow rollback. | `10`    |
+
+### karpenter.strategy Rolling update configuration parameters.
+
+| Name                                      | Description                                                          | Value                     |
+| ----------------------------------------- | -------------------------------------------------------------------- | ------------------------- |
+| `karpenter.podLabels`                     | Additional labels for the Karpenter pod.                             | `{}`                      |
+| `karpenter.podAnnotations`                | Additional annotations for the Karpenter pod.                        | `{}`                      |
+| `karpenter.priorityClassName`             | PriorityClass name for the pod.                                      | `system-cluster-critical` |
+| `karpenter.terminationGracePeriodSeconds` | Override the default termination grace period for the pod.           | `nil`                     |
+| `karpenter.hostNetwork`                   | Bind the pod to the host network (required when using a custom CNI). | `false`                   |
+| `karpenter.dnsPolicy`                     | Configure the DNS Policy for the pod.                                | `Default`                 |
+| `karpenter.dnsConfig`                     | Configure DNS Config for the pod.                                    | `{}`                      |
+
+### karpenter.affinity Affinity rules for scheduling the pod.
+
+| Name                     | Description                     | Value |
+| ------------------------ | ------------------------------- | ----- |
+| `karpenter.extraVolumes` | Additional volumes for the pod. | `[]`  |
+
+### karpenter.controller Karpenter controller configuration
+
+| Name                                       | Description                                                        | Value                                                                     |
+| ------------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `karpenter.controller.image.repository`    | Repository path to the controller image.                           | `public.ecr.aws/karpenter/controller`                                     |
+| `karpenter.controller.image.tag`           | Tag of the controller image.                                       | `v0.33.1`                                                                 |
+| `karpenter.controller.image.digest`        | SHA256 digest of the controller image.                             | `sha256:7f484951baf70d1574d6408be3947a3ca5f54463c2d1f29993b492e7e916ef11` |
+| `karpenter.controller.env`                 | Additional environment variables for the controller pod.           | `[]`                                                                      |
+| `karpenter.controller.envFrom`             | Additional environment variables from config map or secret.        | `[]`                                                                      |
+| `karpenter.controller.resources`           | Resources for the controller pod.                                  | `{}`                                                                      |
+| `karpenter.controller.extraVolumeMounts`   | Additional volumeMounts for the controller pod.                    | `[]`                                                                      |
+| `karpenter.controller.sidecarContainer`    | Additional sidecar container configuration for the controller pod. | `[]`                                                                      |
+| `karpenter.controller.sidecarVolumeMounts` | Additional volume mounts for the sidecar container.                | `[]`                                                                      |
+| `karpenter.controller.metrics.port`        | The container port to use for metrics.                             | `8000`                                                                    |
+| `karpenter.controller.healthProbe.port`    | The container port to use for the http health probe.               | `8081`                                                                    |
+
+### karpenter.webhook Webhook configuration
+
+| Name                             | Description                                             | Value   |
+| -------------------------------- | ------------------------------------------------------- | ------- |
+| `karpenter.webhook.enabled`      | Whether to enable the webhooks and webhook permissions. | `false` |
+| `karpenter.webhook.port`         | The container port to use for the webhook.              | `8443`  |
+| `karpenter.webhook.metrics.port` | The container port to use for webhook metrics.          | `8001`  |
+| `karpenter.logLevel`             | Global log level, defaults to 'info'                    | `info`  |
+
+### karpenter.logConfig Log configuration (Deprecated: Logging configuration will be dropped by v1, use logLevel instead)
+
+| Name                                      | Description                                                        | Value        |
+| ----------------------------------------- | ------------------------------------------------------------------ | ------------ |
+| `karpenter.logConfig.enabled`             | Whether to enable provisioning and mounting the log ConfigMap.     | `false`      |
+| `karpenter.logConfig.outputPaths`         | Log output paths - defaults to stdout only.                        | `["stdout"]` |
+| `karpenter.logConfig.errorOutputPaths`    | Log error output paths - defaults to stderr only.                  | `["stderr"]` |
+| `karpenter.logConfig.logEncoding`         | Log encoding - defaults to json - must be one of 'json', 'console' | `json`       |
+| `karpenter.logConfig.logLevel.global`     | Global log level, defaults to 'info'.                              | `info`       |
+| `karpenter.logConfig.logLevel.controller` | Controller log level, defaults to 'info'.                          | `info`       |
+| `karpenter.logConfig.logLevel.webhook`    | Webhook log level, defaults to 'error'.                            | `error`      |
+
+### karpenter.settings Global settings to configure Karpenter
+
+| Name                                         | Description                                                                                                                                                                                                                | Value   |
+| -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `karpenter.settings.batchMaxDuration`        | The maximum length of a batch window.                                                                                                                                                                                      | `10s`   |
+| `karpenter.settings.batchIdleDuration`       | The maximum amount of time with no new ending pods that if exceeded ends the current batching window.                                                                                                                      | `1s`    |
+| `karpenter.settings.assumeRoleARN`           | Role to assume for calling AWS services.                                                                                                                                                                                   | `""`    |
+| `karpenter.settings.assumeRoleDuration`      | Duration of assumed credentials in minutes. Default value is 15 minutes. Not used unless assumeRoleARN set.                                                                                                                | `15m`   |
+| `karpenter.settings.clusterCABundle`         | Cluster CA bundle for TLS configuration of provisioned nodes. If not set, this is taken from the controller's TLS configuration for the API server.                                                                        | `""`    |
+| `karpenter.settings.clusterName`             | Cluster name.                                                                                                                                                                                                              | `""`    |
+| `karpenter.settings.clusterEndpoint`         | Cluster endpoint. If not set, will be discovered during startup (EKS only).                                                                                                                                                | `""`    |
+| `karpenter.settings.isolatedVPC`             | If true, assume AWS services without a VPC endpoint cannot be reached. This also disables look-ups to the AWS pricing endpoint.                                                                                            | `false` |
+| `karpenter.settings.vmMemoryOverheadPercent` | The VM memory overhead as a percent, subtracted from total memory for all instance types.                                                                                                                                  | `0.075` |
+| `karpenter.settings.interruptionQueue`       | Name of the SQS queue to use for interruption handling. If not specified, interruption handling is disabled. Enabling requires additional permissions on the controller service account, as outlined in the documentation. | `""`    |
+| `karpenter.settings.reservedENIs`            | Number of reserved ENIs not included in max-pods or kube-reserved calculations. Often used in VPC CNI custom networking.                                                                                                   | `0`     |
+
+### karpenter.settings.featureGates Feature gate configuration values. Feature gates follow the same graduation process and requirements as in Kubernetes.
+
+| Name                                    | Description                                                                                                                                                                           | Value  |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| `karpenter.settings.featureGates.drift` | Enable/disable the drift disruption method to watch for drift between deployed nodes and the desired state set in nodepools and nodeclasses. Drift is in BETA and enabled by default. | `true` |

--- a/canso-data-plane/canso-karpenter/values.yaml
+++ b/canso-data-plane/canso-karpenter/values.yaml
@@ -1,20 +1,20 @@
 karpenter:
-  ## @param nameOverride String to override partial name passed in helm install command
+  ## @param karpenter.nameOverride String to override partial name passed in helm install command
   ##
   nameOverride: "canso-karpenter"
-  ## @param fullnameOverride String to override full name passed in helm install command
+  ## @param karpenter.fullnameOverride String to override full name passed in helm install command
   ##
   fullnameOverride: ""
-  ## @param additionalLabels Additional labels to add into metadata.
+  ## @param karpenter.additionalLabels Additional labels to add into metadata.
   ##
   additionalLabels: {}
-  ## @param additionalAnnotations Additional annotations to add into metadata.
+  ## @param karpenter.additionalAnnotations Additional annotations to add into metadata.
   ##
   additionalAnnotations: {}
-  ## @param imagePullPolicy Image pull policy for Docker images.
+  ## @param karpenter.imagePullPolicy Image pull policy for Docker images.
   ##
   imagePullPolicy: IfNotPresent
-  ## @param imagePullSecrets Image pull secrets for Docker images.
+  ## @param karpenter.imagePullSecrets Image pull secrets for Docker images.
   ##
   imagePullSecrets: []
 
@@ -22,79 +22,80 @@ karpenter:
   ################ Service Account
   ####################################################
 
-  ## @section serviceAccount Service account configuration
+  ## @section karpenter.serviceAccount Service account configuration
   serviceAccount:
-    ## @param serviceAccount.create Specifies whether a ServiceAccount should be created.
+    ## @param karpenter.serviceAccount.create Specifies whether a ServiceAccount should be created.
     ##
     create: true
-    ## @param serviceAccount.name The name of the ServiceAccount to use.
+    ## @param karpenter.serviceAccount.name The name of the ServiceAccount to use.
     ##
     name: "karpenter"
-    ## @param serviceAccount.annotations Additional annotations for the ServiceAccount.
+    ## @param karpenter.serviceAccount.annotations Additional annotations for the ServiceAccount.
     ##
     annotations: {}
 
-  ## @param additionalClusterRoleRules Additional rules to add into the ClusterRole.
+  ## @param karpenter.additionalClusterRoleRules Additional rules to add into the ClusterRole.
   ##
   additionalClusterRoleRules: []
 
-  ## @section serviceMonitor Service monitor configuration
+  ## @section karpenter.serviceMonitor Service monitor configuration
   serviceMonitor:
-    ## @param serviceMonitor.enabled Specifies whether a ServiceMonitor should be created.
+    ## @param karpenter.serviceMonitor.enabled Specifies whether a ServiceMonitor should be created.
     ##
     enabled: false
-    ## @param serviceMonitor.additionalLabels Additional labels for the ServiceMonitor.
+    ## @param karpenter.serviceMonitor.additionalLabels Additional labels for the ServiceMonitor.
     ##
     additionalLabels: {}
-    ## @param serviceMonitor.endpointConfig Endpoint configuration for the ServiceMonitor.
+    ## @param karpenter.serviceMonitor.endpointConfig Endpoint configuration for the ServiceMonitor.
     ##
     endpointConfig: {}
 
-  ## @param replicas Number of replicas for the Karpenter controller.
+  ## @param karpenter.replicas Number of replicas for the Karpenter controller.
   ##
   replicas: 2
-  ## @param revisionHistoryLimit The number of old ReplicaSets to retain to allow rollback.
+  ## @param karpenter.revisionHistoryLimit The number of old ReplicaSets to retain to allow rollback.
   ##
   revisionHistoryLimit: 10
 
-  ## @param strategy Rolling update configuration parameters.
+  ## @section karpenter.strategy Rolling update configuration parameters.
   ##
   strategy:
+    ## @skip karpenter.strategy.rollingUpdate
     rollingUpdate:
       maxUnavailable: 1
 
-  ## @param podLabels Additional labels for the Karpenter pod.
+  ## @param karpenter.podLabels Additional labels for the Karpenter pod.
   ##
   podLabels: {}
-  ## @param podAnnotations Additional annotations for the Karpenter pod.
+  ## @param karpenter.podAnnotations Additional annotations for the Karpenter pod.
   ##
   podAnnotations: {}
 
-  ## @param podDisruptionBudget Pod disruption budget configuration.
+  ## @skip karpenter.podDisruptionBudget Pod disruption budget configuration.
   ##
   podDisruptionBudget:
     name: karpenter
     maxUnavailable: 1
-  ## @param priorityClassName PriorityClass name for the pod.
+  ## @param karpenter.priorityClassName PriorityClass name for the pod.
   ##
   priorityClassName: system-cluster-critical
 
-  ## @param terminationGracePeriodSeconds Override the default termination grace period for the pod.
+  ## @param karpenter.terminationGracePeriodSeconds Override the default termination grace period for the pod.
   ##
   terminationGracePeriodSeconds:
 
-  ## @param hostNetwork Bind the pod to the host network (required when using a custom CNI).
+  ## @param karpenter.hostNetwork Bind the pod to the host network (required when using a custom CNI).
   ##
   hostNetwork: false
-  ## @param dnsPolicy Configure the DNS Policy for the pod.
+  ## @param karpenter.dnsPolicy Configure the DNS Policy for the pod.
   ##
   dnsPolicy: Default
 
-  ## @param dnsConfig Configure DNS Config for the pod.
+  ## @param karpenter.dnsConfig Configure DNS Config for the pod.
   ##
   dnsConfig: {}
 
-  ## @param nodeSelector Node selectors to schedule the pod to nodes with labels.
+  ## @skip karpenter.nodeSelector Node selectors to schedule the pod to nodes with labels.
   ##
   nodeSelector:
     kubernetes.io/os: linux
@@ -104,33 +105,36 @@ karpenter:
   ################ Affinity
   ####################################################
 
-  ## @param affinity Affinity rules for scheduling the pod.
+  ## @section karpenter.affinity Affinity rules for scheduling the pod.
   ##
   affinity:
+    ## @skip karpenter.affinity.nodeAffinity Node affinity rules for scheduling the pod.
+    ##
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
               - key: karpenter.sh/nodepool
                 operator: DoesNotExist
+    ## @skip karpenter.affinity.podAntiAffinity Pod anti-affinity rules for scheduling the pod.
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         - topologyKey: "kubernetes.io/hostname"
 
-  ## @param topologySpreadConstraints Topology spread constraints to increase controller resilience by distributing pods across zones.
+  ## @skip karpenter.topologySpreadConstraints Topology spread constraints to increase controller resilience by distributing pods across zones.
   ##
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: topology.kubernetes.io/zone
       whenUnsatisfiable: ScheduleAnyway
 
-  ## @param tolerations Tolerations to allow the pod to be scheduled to nodes with taints.
+  ## @skip karpenter.tolerations Tolerations to allow the pod to be scheduled to nodes with taints.
   ##
   tolerations:
     - key: CriticalAddonsOnly
       operator: Exists
 
-  ## @param extraVolumes Additional volumes for the pod.
+  ## @param karpenter.extraVolumes Additional volumes for the pod.
   ##
   extraVolumes: []
 
@@ -139,69 +143,70 @@ karpenter:
   ################ Controller
   ####################################################
 
-  ## @section controller Karpenter controller configuration
+  ## @section karpenter.controller Karpenter controller configuration
   controller:
-    ## @param controller.image Image configuration for the controller
+    ## @subsection karpenter.controller.image Image configuration for the controller
     image:
-      ## @param controller.image.repository Repository path to the controller image.
+      ## @param karpenter.controller.image.repository Repository path to the controller image.
       ##
       repository: public.ecr.aws/karpenter/controller
-      ## @param controller.image.tag Tag of the controller image.
+      ## @param karpenter.controller.image.tag Tag of the controller image.
       ##
       tag: v0.33.1
-      ## @param controller.image.digest SHA256 digest of the controller image.
+      ## @param karpenter.controller.image.digest SHA256 digest of the controller image.
       ##
       digest: sha256:7f484951baf70d1574d6408be3947a3ca5f54463c2d1f29993b492e7e916ef11
 
-    ## @param controller.env Additional environment variables for the controller pod.
+    ## @param karpenter.controller.env Additional environment variables for the controller pod.
     ##
     env: []
 
-    ## @param controller.envFrom Additional environment variables from config map or secret.
+    ## @param karpenter.controller.envFrom Additional environment variables from config map or secret.
     ##
     envFrom: []
 
-    ## @param controller.resources Resources for the controller pod.
+    ## @param karpenter.controller.resources Resources for the controller pod.
     ##
     resources: {}
 
-    ## @param controller.extraVolumeMounts Additional volumeMounts for the controller pod.
+    ## @param karpenter.controller.extraVolumeMounts Additional volumeMounts for the controller pod.
     ##
     extraVolumeMounts: []
 
-    ## @param controller.sidecarContainer Additional sidecar container configuration for the controller pod.
+    ## @param karpenter.controller.sidecarContainer Additional sidecar container configuration for the controller pod.
     ##
     sidecarContainer: []
-    ## @param controller.sidecarVolumeMounts Additional volume mounts for the sidecar container.
+    ## @param karpenter.controller.sidecarVolumeMounts Additional volume mounts for the sidecar container.
     ##
     sidecarVolumeMounts: []
-    ## @param controller.metrics Metrics configuration for the controller pod.
+
+    ## @subsection karpenter.controller.metrics Metrics configuration for the controller pod.
     metrics:
-      ## @param controller.metrics.port The container port to use for metrics.
+      ## @param karpenter.controller.metrics.port The container port to use for metrics.
       ##
       port: 8000
 
-    ## @param controller.healthProbe Health probe configuration for the controller pod.
+    ## @subsection karpenter.controller.healthProbe Health probe configuration for the controller pod.
     healthProbe:
-      ## @param controller.healthProbe.port The container port to use for the http health probe.
+      ## @param karpenter.controller.healthProbe.port The container port to use for the http health probe.
       ##
       port: 8081
 
-  ## @section webhook Webhook configuration
+  ## @section karpenter.webhook Webhook configuration
   webhook:
-    ## @param webhook.enabled Whether to enable the webhooks and webhook permissions.
+    ## @param karpenter.webhook.enabled Whether to enable the webhooks and webhook permissions.
     ##
     enabled: false
-    ## @param webhook.port The container port to use for the webhook.
+    ## @param karpenter.webhook.port The container port to use for the webhook.
     ##
     port: 8443
-    ## @param webhook.metrics Metrics configuration for the webhook.
+    ## @subsection karpenter.webhook.metrics Metrics configuration for the webhook.
     metrics:
-      ## @param webhook.metrics.port The container port to use for webhook metrics.
+      ## @param karpenter.webhook.metrics.port The container port to use for webhook metrics.
       ##
       port: 8001
 
-  ## @param logLevel Global log level, defaults to 'info'
+  ## @param karpenter.logLevel Global log level, defaults to 'info'
   ##
   logLevel: info
 
@@ -210,76 +215,76 @@ karpenter:
   ################ Log Config
   ####################################################
 
-  ## @param logConfig Log configuration (Deprecated: Logging configuration will be dropped by v1, use logLevel instead)
+  ## @section karpenter.logConfig Log configuration (Deprecated: Logging configuration will be dropped by v1, use logLevel instead)
   ##
   logConfig:
-    ## @param logConfig.enabled Whether to enable provisioning and mounting the log ConfigMap.
+    ## @param karpenter.logConfig.enabled Whether to enable provisioning and mounting the log ConfigMap.
     ##
     enabled: false
-    ## @param logConfig.outputPaths Log output paths - defaults to stdout only.
+    ## @param karpenter.logConfig.outputPaths Log output paths - defaults to stdout only.
     ##
     outputPaths:
       - stdout
-    ## @param logConfig.errorOutputPaths Log error output paths - defaults to stderr only.
+    ## @param karpenter.logConfig.errorOutputPaths Log error output paths - defaults to stderr only.
     ##
     errorOutputPaths:
       - stderr
-    ## @param logConfig.logEncoding Log encoding - defaults to json - must be one of 'json', 'console'
+    ## @param karpenter.logConfig.logEncoding Log encoding - defaults to json - must be one of 'json', 'console'
     ##
     logEncoding: json
-    ## @param logConfig.logLevel Component-based log configuration
+    ## @subsection karpenter.logConfig.logLevel Component-based log configuration
     logLevel:
-      ## @param logConfig.logLevel.global Global log level, defaults to 'info'.
+      ## @param karpenter.logConfig.logLevel.global Global log level, defaults to 'info'.
       ##
       global: info
-      ## @param logConfig.logLevel.controller Controller log level, defaults to 'info'.
+      ## @param karpenter.logConfig.logLevel.controller Controller log level, defaults to 'info'.
       ##
       controller: info
-      ## @param logConfig.logLevel.webhook Webhook log level, defaults to 'error'.
+      ## @param karpenter.logConfig.logLevel.webhook Webhook log level, defaults to 'error'.
       ##
       webhook: error
 
-  ## @section settings Global settings to configure Karpenter
+  ## @section karpenter.settings Global settings to configure Karpenter
   settings:
-    ## @param settings.batchMaxDuration The maximum length of a batch window.
+    ## @param karpenter.settings.batchMaxDuration The maximum length of a batch window.
     ##
     batchMaxDuration: 10s
 
-    ## @param settings.batchIdleDuration The maximum amount of time with no new ending pods that if exceeded ends the current batching window.
+    ## @param karpenter.settings.batchIdleDuration The maximum amount of time with no new ending pods that if exceeded ends the current batching window.
     ##
     batchIdleDuration: 1s
 
-    ## @param settings.assumeRoleARN Role to assume for calling AWS services.
+    ## @param karpenter.settings.assumeRoleARN Role to assume for calling AWS services.
     ##
     assumeRoleARN: ""
 
-    ## @param settings.assumeRoleDuration Duration of assumed credentials in minutes. Default value is 15 minutes. Not used unless assumeRoleARN set.
+    ## @param karpenter.settings.assumeRoleDuration Duration of assumed credentials in minutes. Default value is 15 minutes. Not used unless assumeRoleARN set.
     ##
     assumeRoleDuration: 15m
 
-        ## @param settings.clusterCABundle Cluster CA bundle for TLS configuration of provisioned nodes. If not set, this is taken from the controller's TLS configuration for the API server.
+    ## @param karpenter.settings.clusterCABundle Cluster CA bundle for TLS configuration of provisioned nodes. If not set, this is taken from the controller's TLS configuration for the API server.
     clusterCABundle: ""
 
-    ## @param settings.clusterName Cluster name.
+    ## @param karpenter.settings.clusterName Cluster name.
     clusterName: ""
 
-    ## @param settings.clusterEndpoint Cluster endpoint. If not set, will be discovered during startup (EKS only).
+    ## @param karpenter.settings.clusterEndpoint Cluster endpoint. If not set, will be discovered during startup (EKS only).
     clusterEndpoint: ""
 
-    ## @param settings.isolatedVPC If true, assume AWS services without a VPC endpoint cannot be reached. This also disables look-ups to the AWS pricing endpoint.
+    ## @param karpenter.settings.isolatedVPC If true, assume AWS services without a VPC endpoint cannot be reached. This also disables look-ups to the AWS pricing endpoint.
     isolatedVPC: false
 
-    ## @param settings.vmMemoryOverheadPercent The VM memory overhead as a percent, subtracted from total memory for all instance types.
+    ## @param karpenter.settings.vmMemoryOverheadPercent The VM memory overhead as a percent, subtracted from total memory for all instance types.
     vmMemoryOverheadPercent: 0.075
 
-    ## @param settings.interruptionQueue Name of the SQS queue to use for interruption handling. If not specified, interruption handling is disabled. Enabling requires additional permissions on the controller service account, as outlined in the documentation.
+    ## @param karpenter.settings.interruptionQueue Name of the SQS queue to use for interruption handling. If not specified, interruption handling is disabled. Enabling requires additional permissions on the controller service account, as outlined in the documentation.
     interruptionQueue: ""
 
-    ## @param settings.reservedENIs Number of reserved ENIs not included in max-pods or kube-reserved calculations. Often used in VPC CNI custom networking.
+    ## @param karpenter.settings.reservedENIs Number of reserved ENIs not included in max-pods or kube-reserved calculations. Often used in VPC CNI custom networking.
     reservedENIs: "0"
 
-    ## @section settings.featureGates Feature gate configuration values. Feature gates follow the same graduation process and requirements as in Kubernetes.
+    ## @section karpenter.settings.featureGates Feature gate configuration values. Feature gates follow the same graduation process and requirements as in Kubernetes.
     featureGates:
-      ## @param settings.featureGates.drift Enable/disable the drift disruption method to watch for drift between deployed nodes and the desired state set in nodepools and nodeclasses. Drift is in BETA and enabled by default.
+      ## @param karpenter.settings.featureGates.drift Enable/disable the drift disruption method to watch for drift between deployed nodes and the desired state set in nodepools and nodeclasses. Drift is in BETA and enabled by default.
       drift: true
-
+    

--- a/canso-data-plane/canso-online-feature-service/README.md
+++ b/canso-data-plane/canso-online-feature-service/README.md
@@ -1,1 +1,70 @@
 ## Parameters
+
+### spec
+
+| Name                | Description                           | Value                          |
+| ------------------- | ------------------------------------- | ------------------------------ |
+| `spec.service_name` | Name of the service to be deployed    | `canso-online-fs`              |
+| `nameOverride`      | Override the name of the service      | `canso-online-feature`         |
+| `fullnameOverride`  | Override the full name of the service | `canso-online-feature-service` |
+
+### External Secrets Config
+
+| Name                                     | Description                                                                                       | Value                            |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------- |
+| `external_secret.enabled`                | Enable the creation of the secret                                                                 | `true`                           |
+| `external_secret.name`                   | The name of the secret that will be created                                                       | `canso-online-fs`                |
+| `external_secret.cluster_secret_role`    | The name of the cluster secret role creted in the cluster                                         | `secretstore-by-role`            |
+| `external_secret.target_secret_name`     | The name of the secret that will be created                                                       | `docker-secret-cred`             |
+| `external_secret.target_secret_type`     | The type of the secret that will be created                                                       | `kubernetes.io/dockerconfigjson` |
+| `external_secret.target_secret_name_key` | The key within the secret in the external secrets store that holds the Docker configuration JSON. | `.dockerconfigjson`              |
+| `external_secret.aws_secret_name`        | The path to the secret in AWS Secrets Manager that contains the Docker credentials                | `stage/dockerhub`                |
+| `external_secret.aws_secret_key`         | The key within the secret in AWS Secrets Manager that contains the Docker credentials.            | `dockerhub`                      |
+
+### Deployment 
+
+| Name                                                  | Description                                        | Value                |
+| ----------------------------------------------------- | -------------------------------------------------- | -------------------- |
+| `deployment.ImagePullSecrets.enabled`                 | Enable the creation of the secret                  | `true`               |
+| `deployment.ImagePullSecrets.private_registry_secret` | The name of the secret created by external secrets | `docker-secret-cred` |
+| `deployment.replicaCount`                             | Number of replicas to deploy                       | `2`                  |
+
+### deployment.image 
+
+| Name                          | Description                                                    | Value                                    |
+| ----------------------------- | -------------------------------------------------------------- | ---------------------------------------- |
+| `deployment.image.repository` | The image repository                                           | `shaktimaanbot/feature-retrieval-server` |
+| `deployment.image.pullPolicy` | Image pull policy                                              | `IfNotPresent`                           |
+| `deployment.image.tag`        | Overrides the image tag whose default is the chart appVersion. | `v0.0.1`                                 |
+| `deployment.enableEnv`        | Enable the environment variables                               | `false`                                  |
+| `deployment.enableEnvSecrets` | Enable the environment variables from secrets                  | `false`                                  |
+
+### autoscaling 
+
+| Name                  | Description                     | Value   |
+| --------------------- | ------------------------------- | ------- |
+| `autoscaling.enabled` | enable autoscaling for the pods | `false` |
+
+### taint 
+
+| Name            | Description                     | Value   |
+| --------------- | ------------------------------- | ------- |
+| `taint.enabled` | enabletaint for deployment pods | `false` |
+
+### Service
+
+| Name                 | Description                     | Value             |
+| -------------------- | ------------------------------- | ----------------- |
+| `service.name`       | The name of the service         | `canso-online-fs` |
+| `service.app`        | The app name for service labels | `canso-online-fs` |
+| `service.targetport` | The target port for the service | `8080`            |
+
+### Ingress
+
+| Name                       | Description                     | Value    |
+| -------------------------- | ------------------------------- | -------- |
+| `ingress.enabled`          | Enable the ingress              | `true`   |
+| `ingress.host`             | The host for the ingress        | `""`     |
+| `ingress.path`             | The path for path based routing | `/`      |
+| `ingress.pathType`         | The path type for the ingress   | `Prefix` |
+| `ingress.ingressClassName` | The ingress class name          | `alb`    |

--- a/canso-data-plane/canso-online-feature-service/values.yaml
+++ b/canso-data-plane/canso-online-feature-service/values.yaml
@@ -6,7 +6,7 @@ spec:
 ## @param nameOverride Override the name of the service
 nameOverride: "canso-online-feature"
 
-## @param fullNameOverride Override the full name of the service
+## @param fullnameOverride Override the full name of the service
 fullnameOverride: "canso-online-feature-service"
 
 ##############################################################################################
@@ -33,10 +33,10 @@ external_secret:
   ## @param external_secret.target_secret_name_key The key within the secret in the external secrets store that holds the Docker configuration JSON.
   ##
   target_secret_name_key: .dockerconfigjson
-  ## @param external_Secret.aws_secret_name The path to the secret in AWS Secrets Manager that contains the Docker credentials
+  ## @param external_secret.aws_secret_name The path to the secret in AWS Secrets Manager that contains the Docker credentials
   ##
   aws_secret_name: stage/dockerhub
-  ## @param external_Secret.aws_secret_key The key within the secret in AWS Secrets Manager that contains the Docker credentials.
+  ## @param external_secret.aws_secret_key The key within the secret in AWS Secrets Manager that contains the Docker credentials.
   ##
   aws_secret_key: dockerhub
 
@@ -47,26 +47,28 @@ external_secret:
 ## @section Deployment 
 deployment:
 
-  ## @subsection imagepullsecrets
+  ## @subsection ImagePullSecrets
   ImagePullSecrets:
-    ## @param deployment.imagepullsecrets.enabled Enable the creation of the secret
+    ## @param deployment.ImagePullSecrets.enabled Enable the creation of the secret
     ##
     enabled: true
-    ## @param deployment.imagepullsecrets.private_registry_secret The name of the secret created by external secrets
+    ## @param deployment.ImagePullSecrets.private_registry_secret The name of the secret created by external secrets
     ##
     private_registry_secret: *image_pull_secret_name
 
   ## @param deployment.replicaCount Number of replicas to deploy
   replicaCount: 2
 
+  ## @section deployment.image 
   image:
     ## @param deployment.image.repository The image repository
     repository: shaktimaanbot/feature-retrieval-server
     ## @param deployment.image.pullPolicy Image pull policy
     pullPolicy: IfNotPresent
-    # Overrides the image tag whose default is the chart appVersion.
+    ## @param deployment.image.tag Overrides the image tag whose default is the chart appVersion.
     tag: v0.0.1
-  ## @param deployment.resources The resources requests and limits for the container.
+
+  ## @skip deployment.resources The resources requests and limits for the container.
   resources:
     limits:
       cpu: "400m"
@@ -79,11 +81,14 @@ deployment:
   ## @param deployment.enableEnvSecrets Enable the environment variables from secrets
   enableEnvSecrets: false
 
-## @param autoscaling Enable autoscaling for deployment pods
+## @section autoscaling 
 autoscaling:
+  ## @param autoscaling.enabled enable autoscaling for the pods
   enabled: false
-## @param taint Enable taint for deployment pods
+
+## @section taint 
 taint:
+  ## @param taint.enabled enabletaint for deployment pods
   enabled: false
 
 ##############################################################################################
@@ -116,7 +121,7 @@ ingress:
   pathType: Prefix
   ## @param ingress.ingressClassName The ingress class name 
   ingressClassName: alb
-  ## @param ingress.annotations The annotations for the ingress
+  ## @skip ingress.annotations The annotations for the ingress
   annotations:
     alb.ingress.kubernetes.io/actions.ssl-redirect: '{"Type": "redirect", "RedirectConfig": { "Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
     alb.ingress.kubernetes.io/certificate-arn: '' 

--- a/canso-data-plane/canso-workflow-orchestrator/README.md
+++ b/canso-data-plane/canso-workflow-orchestrator/README.md
@@ -1,1 +1,49 @@
 ## Parameters
+
+### spec
+
+| Name                | Description              | Value                         |
+| ------------------- | ------------------------ | ----------------------------- |
+| `spec.service_name` | Service name             | `canso-workflow-orchestrator` |
+| `spec.namespace`    | Namespace for deployment | `airflow`                     |
+| `replicaCount`      | Number of replicas       | `1`                           |
+
+### image
+
+| Name               | Description                                                   | Value                       |
+| ------------------ | ------------------------------------------------------------- | --------------------------- |
+| `image.repository` | Image repository                                              | `shaktimaanbot/jerry-image` |
+| `image.pullPolicy` | Image pull policy                                             | `Always`                    |
+| `image.tag`        | Overrides the image tag whose default is the chart appVersion | `v1.0.4`                    |
+
+### external_secret
+
+| Name                                     | Description                                        | Value                            |
+| ---------------------------------------- | -------------------------------------------------- | -------------------------------- |
+| `external_secret.enabled`                | Enable external secret                             | `true`                           |
+| `external_secret.cluster_secret_role`    | Name of Cluster secret role created in the cluster | `secretstore-by-role`            |
+| `external_secret.name`                   | The name of the secret that will be created        | `canso-workflow-orchestrator`    |
+| `external_secret.target_secret_name`     | name of the target kubernetes secret               | `docker-secret-cred`             |
+| `external_secret.target_secret_type`     | type of the target kubernetes secret               | `kubernetes.io/dockerconfigjson` |
+| `external_secret.target_secret_name_key` | key of the kubernetes secret                       | `.dockerconfigjson`              |
+| `external_secret.aws_secret_name`        | name of the AWS secret                             | `stage/dockerhub`                |
+| `external_secret.aws_secret_key`         | key of the kubernetes secret                       | `dockerhub`                      |
+| `nameOverride`                           | Override the name of the service                   | `canso-workflow-orchestrator`    |
+| `fullnameOverride`                       | Override the full name of the service              | `""`                             |
+| `podAnnotations`                         | Annotations to be added to the deploymetn pods     | `{}`                             |
+| `persistentVolumeClaim.existingClaim`    | Write in existing PVC                              | `airflow-pvc`                    |
+| `podSecurityContext`                     | Security context for the deployment pods           | `{}`                             |
+| `securityContext`                        | Security context for the deployment pods           | `{}`                             |
+
+### service
+
+| Name           | Description                             | Value      |
+| -------------- | --------------------------------------- | ---------- |
+| `service.type` | Type of the service                     | `NodePort` |
+| `service.port` | Port of the service                     | `3000`     |
+| `ingress`      | Ingress configuration for the service   | `{}`       |
+| `resources`    | Pod resource requests and limits        | `{}`       |
+| `autoscaling`  | Horizontal pod autoscaler configuration | `{}`       |
+| `nodeSelector` | Node labels for pod assignment          | `{}`       |
+| `tolerations`  | Tolerations for pod assignment          | `[]`       |
+| `affinity`     | Affinity for pod assignment             | `{}`       |

--- a/canso-data-plane/canso-workflow-orchestrator/values.yaml
+++ b/canso-data-plane/canso-workflow-orchestrator/values.yaml
@@ -3,9 +3,9 @@
 
 ## @section spec
 spec:
-  ## @param service_name Service name
+  ## @param spec.service_name Service name
   service_name: &service_name "canso-workflow-orchestrator"
-  ## @param namespace Namespace for deployment
+  ## @param spec.namespace Namespace for deployment
   namespace: airflow
 
 
@@ -14,10 +14,10 @@ replicaCount: 1
 
 ## @section image
 image:
-  ## @param repository Image repository
+  ## @param image.repository Image repository
   ##
   repository: shaktimaanbot/jerry-image
-  ## @param pullPolicy Image pull policy
+  ## @param image.pullPolicy Image pull policy
   ##
   pullPolicy: Always
   ## @param image.tag Overrides the image tag whose default is the chart appVersion
@@ -29,6 +29,8 @@ external_secret:
   ## @param external_secret.enabled Enable external secret
   ##
   enabled: true
+  ## @param external_secret.cluster_secret_role Name of Cluster secret role created in the cluster
+  ##
   cluster_secret_role: secretstore-by-role
   ## @param external_secret.name The name of the secret that will be created
   ##
@@ -49,7 +51,7 @@ external_secret:
   ##
   aws_secret_key: dockerhub
 
-## @param imagePullSecrets Docker registry secret names as an array
+## @skip imagePullSecrets Docker registry secret names as an array
 ##
 imagePullSecrets:
   - name:  *image_pull_secret_name
@@ -58,15 +60,15 @@ imagePullSecrets:
 ##
 nameOverride: "canso-workflow-orchestrator"
 
-## @param fullNameOverride Override the full name of the service
+## @param fullnameOverride Override the full name of the service
 ##
 fullnameOverride: ""
 
-## @param podAnnotation Annotations to be added to the deploymetn pods
+## @param podAnnotations Annotations to be added to the deploymetn pods
 ##
 podAnnotations: {}
 
-## @param persistentVolumeClaim Use an existing PVC to provide persistence for the volume
+## @subsection persistentVolumeClaim Use an existing PVC to provide persistence for the volume
 persistentVolumeClaim:
   ## @param persistentVolumeClaim.existingClaim Write in existing PVC
   existingClaim: airflow-pvc
@@ -146,7 +148,7 @@ tolerations: []
 ##
 affinity: {}
 
-## @param redinessProbe Readiness probe configuration
+## @skip readinessProbe Readiness probe configuration
 ##
 readinessProbe:
     enabled: false 
@@ -157,7 +159,7 @@ readinessProbe:
     path: /healthz
     port: http
 
-## @param livenessProbe Liveness probe configuration
+## @skip livenessProbe Liveness probe configuration
 ##
 livenessProbe:
   enabled: false 


### PR DESCRIPTION
### Description

The github actions is unable to create the README.md file even after adding the readme to main branch. REf- https://github.com/Yugen-ai/canso-helm-charts/actions/runs/9842921039/job/27173468291

Creating it locally -

```
readme-generator --values="canso-aws-eks-superchart/values.yaml" --readme="canso-aws-eks-superchart/README.md"
```

1st part of the Readme Docs Generation - https://github.com/Yugen-ai/canso-helm-charts/pull/11