### PR TITLE
Helm charts to reference images that are release candidates

### DIFF
--- a/canso-data-plane/canso-agent/README.md
+++ b/canso-data-plane/canso-agent/README.md
@@ -84,11 +84,11 @@
 
 ### Image Configuration  
 
-| Name                                     | Description               | Value                           |
-| ---------------------------------------- | ------------------------- | ------------------------------- |
-| `cansoAgent.deployment.image.repository` | repository for the image  | `shaktimaanbot/dev-agent-image` |
-| `cansoAgent.deployment.image.pullPolicy` | Pull policy for the image | `Always`                        |
-| `cansoAgent.deployment.image.tag`        | Tag for the image         | `v0.0.1-python-3.8-slim`        |
+| Name                                     | Description               | Value                                  |
+| ---------------------------------------- | ------------------------- | -------------------------------------- |
+| `cansoAgent.deployment.image.repository` | repository for the image  | `shaktimaanbot/dev-agent-image`        |
+| `cansoAgent.deployment.image.pullPolicy` | Pull policy for the image | `Always`                               |
+| `cansoAgent.deployment.image.tag`        | Tag for the image         | `v0.0.5-python-3.8-slim@sha256:xxxxxx` |
 
 ### resources configuration
 

--- a/canso-data-plane/canso-agent/values.yaml
+++ b/canso-data-plane/canso-agent/values.yaml
@@ -171,7 +171,7 @@ cansoAgent:
       pullPolicy: Always
       ## @param cansoAgent.deployment.image.tag Tag for the image
       ##
-      tag: v0.0.1-python-3.8-slim
+      tag: v0.0.5-python-3.8-slim@sha256:xxxxxx # SHA TO BE UPDATED
     ## @section resources configuration
     resources:
       ## @section resources limits configuration

--- a/canso-data-plane/canso-aws-eks-superchart/README.md
+++ b/canso-data-plane/canso-aws-eks-superchart/README.md
@@ -134,25 +134,25 @@
 
 ### Jerry
 
-| Name                            | Description                                                            | Value      |
-| ------------------------------- | ---------------------------------------------------------------------- | ---------- |
-| `jerry.enabled`                 | Flag to enable Jerry.                                                  | `true`     |
-| `jerry.external_secret.enabled` | Flag to enable the creation of a secret in the same namespace as jerry | `true`     |
-| `jerry.image.tag`               | Tag of the Jerry image.                                                | `v1.0.4`   |
-| `jerry.service.type`            | Type of the service for Jerry.                                         | `NodePort` |
-| `jerry.service.port`            | Port of the service for Jerry.                                         | `3000`     |
-| `jerry.readinessProbe.enabled`  | Flag to enable readiness probe for Jerry.                              | `false`    |
-| `jerry.livenessProbe.enabled`   | Flag to enable liveness probe for Jerry.                               | `false`    |
+| Name                            | Description                                                            | Value                |
+| ------------------------------- | ---------------------------------------------------------------------- | -------------------- |
+| `jerry.enabled`                 | Flag to enable Jerry.                                                  | `true`               |
+| `jerry.external_secret.enabled` | Flag to enable the creation of a secret in the same namespace as jerry | `true`               |
+| `jerry.image.tag`               | Tag of the Jerry image.                                                | `v1.0.4@sha256:xxxx` |
+| `jerry.service.type`            | Type of the service for Jerry.                                         | `NodePort`           |
+| `jerry.service.port`            | Port of the service for Jerry.                                         | `3000`               |
+| `jerry.readinessProbe.enabled`  | Flag to enable readiness probe for Jerry.                              | `false`              |
+| `jerry.livenessProbe.enabled`   | Flag to enable liveness probe for Jerry.                               | `false`              |
 
 ### Online Feature Service
 
-| Name                               | Description                                             | Value    |
-| ---------------------------------- | ------------------------------------------------------- | -------- |
-| `onlineFS.enabled`                 | Flag to enable Online Feature Store.                    | `true`   |
-| `onlineFS.external_secret.enabled` | Flag to enable the creation of an external secret       | `true`   |
-| `onlineFS.deployment.replicaCount` | Number of replicas for Online Feature Store deployment. | `1`      |
-| `onlineFS.deployment.image.tag`    | Tag of the Online Feature Store image.                  | `v0.0.1` |
-| `onlineFS.ingress.enabled`         | Flag to enable ingress for Online Feature Store.        | `false`  |
+| Name                               | Description                                             | Value                  |
+| ---------------------------------- | ------------------------------------------------------- | ---------------------- |
+| `onlineFS.enabled`                 | Flag to enable Online Feature Store.                    | `true`                 |
+| `onlineFS.external_secret.enabled` | Flag to enable the creation of an external secret       | `true`                 |
+| `onlineFS.deployment.replicaCount` | Number of replicas for Online Feature Store deployment. | `1`                    |
+| `onlineFS.deployment.image.tag`    | Tag of the Online Feature Store image.                  | `v0.0.1@sha256:xxxxxx` |
+| `onlineFS.ingress.enabled`         | Flag to enable ingress for Online Feature Store.        | `false`                |
 
 ### Airflow Jobs
 

--- a/canso-data-plane/canso-aws-eks-superchart/values.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/values.yaml
@@ -358,7 +358,7 @@ jerry:
   image:
     ## @param jerry.image.tag Tag of the Jerry image.
     ##
-    tag: "v1.0.4"
+    tag: "v1.0.4@sha256:xxxx" # SHA TO BE UPDATED
     
   ## @subsection jerry.service 
   service:
@@ -404,7 +404,7 @@ onlineFS:
     image:
       ## @param onlineFS.deployment.image.tag Tag of the Online Feature Store image.
       ##
-      tag: v0.0.1
+      tag: v0.0.1@sha256:xxxxxx # SHA TO BE ADDED, Github workflow to be added in Platform Services as well.
 
   ingress:
     ## @param onlineFS.ingress.enabled Flag to enable ingress for Online Feature Store.

--- a/canso-data-plane/canso-online-feature-service/README.md
+++ b/canso-data-plane/canso-online-feature-service/README.md
@@ -35,7 +35,7 @@
 | ----------------------------- | -------------------------------------------------------------- | ---------------------------------------- |
 | `deployment.image.repository` | The image repository                                           | `shaktimaanbot/feature-retrieval-server` |
 | `deployment.image.pullPolicy` | Image pull policy                                              | `IfNotPresent`                           |
-| `deployment.image.tag`        | Overrides the image tag whose default is the chart appVersion. | `v0.0.1`                                 |
+| `deployment.image.tag`        | Overrides the image tag whose default is the chart appVersion. | `v0.0.1@sha256:xxxxxx`                   |
 | `deployment.enableEnv`        | Enable the environment variables                               | `false`                                  |
 | `deployment.enableEnvSecrets` | Enable the environment variables from secrets                  | `false`                                  |
 

--- a/canso-data-plane/canso-online-feature-service/values.yaml
+++ b/canso-data-plane/canso-online-feature-service/values.yaml
@@ -66,7 +66,7 @@ deployment:
     ## @param deployment.image.pullPolicy Image pull policy
     pullPolicy: IfNotPresent
     ## @param deployment.image.tag Overrides the image tag whose default is the chart appVersion.
-    tag: v0.0.1
+    tag: v0.0.1@sha256:xxxxxx # SHA TO BE ADDED, Github workflow to be added in Platform Services as well.
 
   ## @skip deployment.resources The resources requests and limits for the container.
   resources:

--- a/canso-data-plane/canso-workflow-orchestrator/README.md
+++ b/canso-data-plane/canso-workflow-orchestrator/README.md
@@ -14,7 +14,7 @@
 | ------------------ | ------------------------------------------------------------- | --------------------------- |
 | `image.repository` | Image repository                                              | `shaktimaanbot/jerry-image` |
 | `image.pullPolicy` | Image pull policy                                             | `Always`                    |
-| `image.tag`        | Overrides the image tag whose default is the chart appVersion | `v1.0.4`                    |
+| `image.tag`        | Overrides the image tag whose default is the chart appVersion | `v1.0.4@sha256:xxxx`        |
 
 ### external_secret
 

--- a/canso-data-plane/canso-workflow-orchestrator/values.yaml
+++ b/canso-data-plane/canso-workflow-orchestrator/values.yaml
@@ -22,7 +22,7 @@ image:
   pullPolicy: Always
   ## @param image.tag Overrides the image tag whose default is the chart appVersion
   ##
-  tag: "v1.0.4"
+  tag: "v1.0.4@sha256:xxxx" # SHA TO BE UPDATED
 
 ## @section external_secret
 external_secret:


### PR DESCRIPTION
As we prep for release, we'll need to add SHA digests to image references in Helm charts/templates. We are going to use SHA digests instead of simple tags such as `latest` or `rc1` etc since they are floating in nature. This is [recommended by Helm as well](https://helm.sh/docs/chart_best_practices/pods/#images) & helps us to use our simpler Github trunk based workflows. Since SHA is immutable, we can merge PRs to `main` w/o impacting images running in Production unless we explicitly change the SHA in the tag.

## TODOs

- [ ] Finalise images in respective repos & get the SHA values
- [ ] Resolve dependencies (e.g. Online feature service is missing the standard Github action we follow)

cc @Yugen-ai/platform-engineering 