### PR TITLE
[NOJIRA] Helm chart updates - secret manager - image updates - version bumps

### DIFF
--- a/canso-data-plane/canso-agent/Chart.yaml
+++ b/canso-data-plane/canso-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-agent/README.md
+++ b/canso-data-plane/canso-agent/README.md
@@ -50,7 +50,7 @@
 | `cansoAgent.external_secret.target_secret_name`     | The name of the secret stored in AWS Secrets Manager                                              | `docker-secret-cred-dev-agent`   |
 | `cansoAgent.external_secret.target_secret_type`     | The type of the secret stored in the external secrets store                                       | `kubernetes.io/dockerconfigjson` |
 | `cansoAgent.external_secret.target_secret_name_key` | The key within the secret in the external secrets store that holds the Docker configuration JSON. | `.dockerconfigjson`              |
-| `cansoAgent.external_secret.aws_secret_name`        | The path to the secret in AWS Secrets Manager that contains the Docker credentials                | `stage/dockerhub`                |
+| `cansoAgent.external_secret.aws_secret_name`        | The path to the secret in AWS Secrets Manager that contains the Docker credentials                | `canso/dockerhub`                |
 | `cansoAgent.external_secret.aws_secret_key`         | The key within the secret in AWS Secrets Manager that contains the Docker credentials.            | `dockerhub`                      |
 
 ### Readiness Probe Configurations

--- a/canso-data-plane/canso-agent/README.md
+++ b/canso-data-plane/canso-agent/README.md
@@ -88,7 +88,7 @@
 | ---------------------------------------- | ------------------------- | ------------------------------- |
 | `cansoAgent.deployment.image.repository` | repository for the image  | `shaktimaanbot/dev-agent-image` |
 | `cansoAgent.deployment.image.pullPolicy` | Pull policy for the image | `Always`                        |
-| `cansoAgent.deployment.image.tag`        | Tag for the image         | `v0.0.1-python-3.8-slim`        |
+| `cansoAgent.deployment.image.tag`        | Tag for the image         | `v0.0.5-python-3.8-slim`        |
 
 ### resources configuration
 

--- a/canso-data-plane/canso-agent/values.yaml
+++ b/canso-data-plane/canso-agent/values.yaml
@@ -174,7 +174,7 @@ cansoAgent:
       pullPolicy: Always
       ## @param cansoAgent.deployment.image.tag Tag for the image
       ##
-      tag: v0.0.1-python-3.8-slim
+      tag: v0.0.5-python-3.8-slim
     ## @section resources configuration
     resources:
       ## @section resources limits configuration

--- a/canso-data-plane/canso-agent/values.yaml
+++ b/canso-data-plane/canso-agent/values.yaml
@@ -106,7 +106,7 @@ cansoAgent:
     target_secret_name_key: .dockerconfigjson
     ## @param cansoAgent.external_secret.aws_secret_name The path to the secret in AWS Secrets Manager that contains the Docker credentials
     ##
-    aws_secret_name: stage/dockerhub
+    aws_secret_name: canso/dockerhub
     ## @param cansoAgent.external_secret.aws_secret_key The key within the secret in AWS Secrets Manager that contains the Docker credentials.
     ##
     aws_secret_key: dockerhub

--- a/canso-data-plane/canso-airflow-jobs/Chart.yaml
+++ b/canso-data-plane/canso-airflow-jobs/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-airflow-jobs/README.md
+++ b/canso-data-plane/canso-airflow-jobs/README.md
@@ -45,7 +45,7 @@
 | `external_secret.enabled`           | Flag to enable External Secrets      | `true`                           |
 | `external_secret.name`              | name of the external secret          | `canso-image-pull-secrets`       |
 | `external_secret.secretKey`         | key of the kubernetes secret         | `.dockerconfigjson`              |
-| `external_secret.remoteRefKey`      | name of the AWS secret               | `stage/dockerhub`                |
+| `external_secret.remoteRefKey`      | name of the AWS secret               | `canso/dockerhub`                |
 | `external_secret.remoteRefProperty` | key of the secret in secrets manager | `dockerhub`                      |
 | `external_secret.targetName`        | name of the target kubernetes secret | `docker-secret-cred`             |
 | `external_secret.targetType`        | type of the target kubernetes secret | `kubernetes.io/dockerconfigjson` |

--- a/canso-data-plane/canso-airflow-jobs/values.yaml
+++ b/canso-data-plane/canso-airflow-jobs/values.yaml
@@ -122,7 +122,7 @@ external_secret:
   secretKey: .dockerconfigjson
   ## @param external_secret.remoteRefKey name of the AWS secret
   ##
-  remoteRefKey: stage/dockerhub
+  remoteRefKey: canso/dockerhub
   ## @param external_secret.remoteRefProperty key of the secret in secrets manager
   ##
   remoteRefProperty: dockerhub

--- a/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
@@ -28,7 +28,7 @@ spec:
       source:
         repoURL: 'https://yugen-ai.github.io/canso-helm-charts'
         chart: canso-agent
-        targetRevision: 0.1.4
+        targetRevision: 0.1.5
         helm:
           values: |-
             config:

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-airflow-jobs.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-airflow-jobs.yaml
@@ -27,7 +27,7 @@ spec:
         namespace: {{ .Values.cansoAirflowJobs.namespace }}
       sources:
       - repoURL: 'https://yugen-ai.github.io/canso-helm-charts'
-        targetRevision: "0.1.1"
+        targetRevision: "0.1.2"
         chart: canso-airflow-jobs
         releaseName: canso-helm-charts/canso-airflow-jobs
         helm:

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/jerry.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/jerry.yaml
@@ -28,7 +28,7 @@ spec:
         namespace: airflow
       sources:
       - repoURL: 'https://yugen-ai.github.io/canso-helm-charts'
-        targetRevision: "0.0.2"
+        targetRevision: "0.0.3"
         chart: canso-workflow-orchestrator
         helm:
           releaseName: "jerry"

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/online-fs.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/online-fs.yaml
@@ -27,7 +27,7 @@ spec:
         server: https://kubernetes.default.svc
       source:
         repoURL: 'https://yugen-ai.github.io/canso-helm-charts'
-        targetRevision: "0.0.2"
+        targetRevision: "0.0.3"
         chart: canso-online-feature-service
         helm:
           values: |

--- a/canso-data-plane/canso-aws-eks-superchart/values.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/values.yaml
@@ -500,13 +500,13 @@ ingress:
     path: "/airflow"
     servicePort: 8080
     annotations: {}
-  - serviceName: online-fs       
+  - serviceName: canso-online-feature       
     namespace: online-fs
     host: "*.com"               
     path: "/online-fs/"
     servicePort: 80
     annotations: 
-      nginx.org/rewrites: "serviceName=online-fs rewrite=/"
+      nginx.org/rewrites: "serviceName=canso-online-feature rewrite=/"
   - serviceName: grafana       
     namespace: grafana
     host: "*.com"               

--- a/canso-data-plane/canso-aws-eks-superchart/values.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/values.yaml
@@ -97,7 +97,7 @@ canso:
   imagePullSecrets:
     - name: canso-image-pull-secrets
       secretKey: .dockerconfigjson # key of the kubernetes secret
-      remoteRefKey: stage/dockerhub # name of AWS secret
+      remoteRefKey: canso/dockerhub # name of AWS secret
       remoteRefProperty: dockerhub # key of the secret in secrets manager
       targetName: docker-secret-cred # name of kubernetes secret
       targetType: kubernetes.io/dockerconfigjson

--- a/canso-data-plane/canso-online-feature-service/Chart.yaml
+++ b/canso-data-plane/canso-online-feature-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-online-feature-service/README.md
+++ b/canso-data-plane/canso-online-feature-service/README.md
@@ -18,7 +18,7 @@
 | `external_secret.target_secret_name`     | The name of the secret that will be created                                                       | `docker-secret-cred`             |
 | `external_secret.target_secret_type`     | The type of the secret that will be created                                                       | `kubernetes.io/dockerconfigjson` |
 | `external_secret.target_secret_name_key` | The key within the secret in the external secrets store that holds the Docker configuration JSON. | `.dockerconfigjson`              |
-| `external_secret.aws_secret_name`        | The path to the secret in AWS Secrets Manager that contains the Docker credentials                | `stage/dockerhub`                |
+| `external_secret.aws_secret_name`        | The path to the secret in AWS Secrets Manager that contains the Docker credentials                | `canso/dockerhub`                |
 | `external_secret.aws_secret_key`         | The key within the secret in AWS Secrets Manager that contains the Docker credentials.            | `dockerhub`                      |
 
 ### Deployment 

--- a/canso-data-plane/canso-online-feature-service/values.yaml
+++ b/canso-data-plane/canso-online-feature-service/values.yaml
@@ -35,7 +35,7 @@ external_secret:
   target_secret_name_key: .dockerconfigjson
   ## @param external_secret.aws_secret_name The path to the secret in AWS Secrets Manager that contains the Docker credentials
   ##
-  aws_secret_name: stage/dockerhub
+  aws_secret_name: canso/dockerhub
   ## @param external_secret.aws_secret_key The key within the secret in AWS Secrets Manager that contains the Docker credentials.
   ##
   aws_secret_key: dockerhub

--- a/canso-data-plane/canso-workflow-orchestrator/Chart.yaml
+++ b/canso-data-plane/canso-workflow-orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-workflow-orchestrator/README.md
+++ b/canso-data-plane/canso-workflow-orchestrator/README.md
@@ -26,7 +26,7 @@
 | `external_secret.target_secret_name`     | name of the target kubernetes secret               | `docker-secret-cred`             |
 | `external_secret.target_secret_type`     | type of the target kubernetes secret               | `kubernetes.io/dockerconfigjson` |
 | `external_secret.target_secret_name_key` | key of the kubernetes secret                       | `.dockerconfigjson`              |
-| `external_secret.aws_secret_name`        | name of the AWS secret                             | `stage/dockerhub`                |
+| `external_secret.aws_secret_name`        | name of the AWS secret                             | `canso/dockerhub`                |
 | `external_secret.aws_secret_key`         | key of the kubernetes secret                       | `dockerhub`                      |
 | `nameOverride`                           | Override the name of the service                   | `canso-workflow-orchestrator`    |
 | `fullnameOverride`                       | Override the full name of the service              | `""`                             |

--- a/canso-data-plane/canso-workflow-orchestrator/values.yaml
+++ b/canso-data-plane/canso-workflow-orchestrator/values.yaml
@@ -46,7 +46,7 @@ external_secret:
   target_secret_name_key: .dockerconfigjson
   ## @param external_secret.aws_secret_name name of the AWS secret
   ##
-  aws_secret_name: stage/dockerhub
+  aws_secret_name: canso/dockerhub
   ## @param external_secret.aws_secret_key key of the kubernetes secret
   ##
   aws_secret_key: dockerhub


### PR DESCRIPTION
### Description

Updates
- Updating secrets names from `stage/dockerhub` to `canso/dockerhub` in all charts
- Updating ingress service name for `online-fs` to `canso-online-feature`

### Testing

Tested in canso-prod-dataplane-cluster

helm template output-

```
# Source: canso-aws-eks-superchart/templates/aws/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: canso-online-feature-ing
  namespace: online-fs
  annotations:
    helm.sh/hook: post-install
    helm.sh/hook-weight: "10"
    nginx.org/mergeable-ingress-type: "minion"
    nginx.org/rewrites: serviceName=canso-online-feature rewrite=/    
spec:
  ingressClassName: "nginx"  
  rules:
  - host: '*.com'
    http:
      paths:
      - path: /online-fs/
        pathType: Prefix
        backend:
          service:
            name: canso-online-feature
            port:
              number: 80
```

external-secrets - 
```
---
              apiVersion: external-secrets.io/v1beta1
              kind: ExternalSecret
              metadata:
                name: canso-image-pull-secrets
                namespace: spark-streaming-jobs
              spec:
                refreshInterval: 1h
                secretStoreRef:
                  name: secretstore-by-role
                  kind: ClusterSecretStore
                target:
                  name: docker-secret-cred
                data:
                  - secretKey: .dockerconfigjson
                    remoteRef:
                      key: canso/dockerhub
                      property: dockerhub

              ---
              apiVersion: external-secrets.io/v1beta1
              kind: ExternalSecret
              metadata:
                name: canso-image-pull-secrets
                namespace: spark-streaming-ml-jobs
              spec:
                refreshInterval: 1h
                secretStoreRef:
                  name: secretstore-by-role
                  kind: ClusterSecretStore
                target:
                  name: docker-secret-cred
                data:
                  - secretKey: .dockerconfigjson
                    remoteRef:
                      key: canso/dockerhub
                      property: dockerhub

              ---
```