### PR TITLE
Add GET verb to Canso Agent

### DIFF
--- a/canso-data-plane/canso-agent/templates/clusterrole.yaml
+++ b/canso-data-plane/canso-agent/templates/clusterrole.yaml
@@ -7,7 +7,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["namespaces", "pods", "resourcequotas", "nodes"]
-    verbs: ["list", "watch"]
+    verbs: ["list", "watch", "get"]
   - apiGroups: ["apps"]
     resources: ["replicasets", "deployments"]
     verbs: ["list", "watch"]


### PR DESCRIPTION
The Canso Agent should have the GET verb. Useful specially for debugging spark jobs.