### PR TITLE
New Superchart Release to reference Canso Agent & Orchestrator releases

### DIFF
--- a/canso-data-plane/canso-aws-eks-superchart/README.md
+++ b/canso-data-plane/canso-aws-eks-superchart/README.md
@@ -135,15 +135,15 @@
 
 ### Jerry
 
-| Name                            | Description                                                            | Value      |
-| ------------------------------- | ---------------------------------------------------------------------- | ---------- |
-| `jerry.enabled`                 | Flag to enable Jerry.                                                  | `true`     |
-| `jerry.external_secret.enabled` | Flag to enable the creation of a secret in the same namespace as jerry | `true`     |
-| `jerry.image.tag`               | Tag of the Jerry image.                                                | `v1.0.4`   |
-| `jerry.service.type`            | Type of the service for Jerry.                                         | `NodePort` |
-| `jerry.service.port`            | Port of the service for Jerry.                                         | `3000`     |
-| `jerry.readinessProbe.enabled`  | Flag to enable readiness probe for Jerry.                              | `false`    |
-| `jerry.livenessProbe.enabled`   | Flag to enable liveness probe for Jerry.                               | `false`    |
+| Name                            | Description                                                            | Value                     |
+| ------------------------------- | ---------------------------------------------------------------------- | ------------------------- |
+| `jerry.enabled`                 | Flag to enable Jerry.                                                  | `true`                    |
+| `jerry.external_secret.enabled` | Flag to enable the creation of a secret in the same namespace as jerry | `true`                    |
+| `jerry.image.tag`               | Tag of the Jerry image.                                                | `v0.0.4-python-3.10-slim` |
+| `jerry.service.type`            | Type of the service for Jerry.                                         | `NodePort`                |
+| `jerry.service.port`            | Port of the service for Jerry.                                         | `3000`                    |
+| `jerry.readinessProbe.enabled`  | Flag to enable readiness probe for Jerry.                              | `false`                   |
+| `jerry.livenessProbe.enabled`   | Flag to enable liveness probe for Jerry.                               | `false`                   |
 
 ### Online Feature Service
 

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
@@ -28,7 +28,7 @@ spec:
       source:
         repoURL: 'https://yugen-ai.github.io/canso-helm-charts'
         chart: canso-agent
-        targetRevision: 0.1.5
+        targetRevision: 0.1.6
         helm:
           values: |-
             config:

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/jerry.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/jerry.yaml
@@ -28,7 +28,7 @@ spec:
         namespace: airflow
       sources:
       - repoURL: 'https://yugen-ai.github.io/canso-helm-charts'
-        targetRevision: "0.0.3"
+        targetRevision: "0.0.4"
         chart: canso-workflow-orchestrator
         helm:
           releaseName: "jerry"

--- a/canso-data-plane/canso-aws-eks-superchart/values.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/values.yaml
@@ -361,7 +361,7 @@ jerry:
   image:
     ## @param jerry.image.tag Tag of the Jerry image.
     ##
-    tag: "v1.0.4"
+    tag: "v0.0.4-python-3.10-slim"
     
   ## @subsection jerry.service 
   service:


### PR DESCRIPTION
- Bump the superchart version
- Superchart references latest Canso Agent release, for reference, see
    - #22 
    - https://github.com/Yugen-ai/canso-helm-charts/releases/tag/canso-agent-0.1.6
    - https://github.com/Yugen-ai/canso-helm-charts/pull/25
    - https://github.com/Yugen-ai/canso-helm-charts/pull/26
    - https://github.com/Yugen-ai/canso-helm-charts/pull/27
    - https://github.com/Yugen-ai/canso-helm-charts/releases/tag/canso-workflow-orchestrator-0.0.4