### PR TITLE
[NOJIRA] Bugfix -Adding template type in External Secrets Job

### DIFF
--- a/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/external-secrets-job.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/external-secrets-job.yaml
@@ -62,6 +62,8 @@ spec:
                   kind: ClusterSecretStore
                 target:
                   name: {{ .targetName }}
+                  template:
+                    type: {{ .targetType }} 
                 data:
                   - secretKey: {{ .secretKey }}
                     remoteRef:
@@ -84,6 +86,8 @@ spec:
                   kind: ClusterSecretStore
                 target:
                   name: {{ .targetName }}
+                  template:
+                    type: {{ .targetType }}
                 data:
                   - secretKey: {{ .secretKey }}
                     remoteRef:


### PR DESCRIPTION
### Description

UPdating target type to `kubernetes.io/dockerconfigjson`. By default the secret created is of type `Opaque`


### Testing

Manually updated on data-plane cluster and the image was successfully pulled. 

cc: @ashishYugen  