### PR TITLE
Use Image Digest to support Immutability + New Versions/Releases

### DIFF
--- a/canso-data-plane/canso-agent/Chart.yaml
+++ b/canso-data-plane/canso-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.6
+version: 0.1.7
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-agent/Chart.yaml
+++ b/canso-data-plane/canso-agent/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.6
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.1"
+appVersion: "v0.0.5-python-3.8-slim"

--- a/canso-data-plane/canso-agent/README.md
+++ b/canso-data-plane/canso-agent/README.md
@@ -84,11 +84,11 @@
 
 ### Image Configuration  
 
-| Name                                     | Description               | Value                           |
-| ---------------------------------------- | ------------------------- | ------------------------------- |
-| `cansoAgent.deployment.image.repository` | repository for the image  | `shaktimaanbot/dev-agent-image` |
-| `cansoAgent.deployment.image.pullPolicy` | Pull policy for the image | `Always`                        |
-| `cansoAgent.deployment.image.tag`        | Tag for the image         | `v0.0.5-python-3.8-slim`        |
+| Name                                     | Description               | Value                                                                     |
+| ---------------------------------------- | ------------------------- | ------------------------------------------------------------------------- |
+| `cansoAgent.deployment.image.repository` | repository for the image  | `shaktimaanbot/dev-agent-image`                                           |
+| `cansoAgent.deployment.image.pullPolicy` | Pull policy for the image | `Always`                                                                  |
+| `cansoAgent.deployment.image.tag`        | Tag for the image         | `sha256:5295215c13198ceb0e41025c472985fe568e07a7757b1bd9ea6a9f8a95545fd6` |
 
 ### resources configuration
 

--- a/canso-data-plane/canso-agent/templates/_helpers.tpl
+++ b/canso-data-plane/canso-agent/templates/_helpers.tpl
@@ -76,3 +76,16 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
+
+{{/*
+Create the image path for the passed in image field
+Credits - https://blog.andyserver.com/2021/09/adding-image-digest-references-to-your-helm-charts/
+*/}}
+{{- define "canso-agent.image" -}}
+{{- $tag := .tag -}}
+{{- if eq (substr 0 7 $tag) "sha256:" -}}
+{{- printf "%s@%s" .repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" .repository $tag -}}
+{{- end -}}
+{{- end -}}

--- a/canso-data-plane/canso-agent/templates/celery-worker-deployment.yaml
+++ b/canso-data-plane/canso-agent/templates/celery-worker-deployment.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: {{ include "canso-agent.serviceAccountName" . }}
       containers:
       - name: {{ include "canso-agent-celery.fullname" . }}
-        image: {{ .Values.cansoAgent.deployment.image.repository }}:{{ .Values.cansoAgent.deployment.image.tag }}
+        image: {{ include "canso-agent.image" (dict "repository" .Values.cansoAgent.deployment.image.repository "tag" (default .Chart.AppVersion .Values.cansoAgent.deployment.image.tag)) }}
         imagePullPolicy: {{ .Values.cansoAgent.deployment.image.pullPolicy }}
         command: ["/bin/sh", "-c"]
         args: ["cd src && celery -A celery_app worker --loglevel=info"]

--- a/canso-data-plane/canso-agent/templates/deployment.yaml
+++ b/canso-data-plane/canso-agent/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: {{ include "canso-agent.fullname" . }}
-        image: {{ .Values.cansoAgent.deployment.image.repository }}:{{ .Values.cansoAgent.deployment.image.tag | default .Chart.AppVersion }}
+        image: {{ include "canso-agent.image" (dict "repository" .Values.cansoAgent.deployment.image.repository "tag" (default .Chart.AppVersion .Values.cansoAgent.deployment.image.tag)) }}
         imagePullPolicy: {{ .Values.cansoAgent.deployment.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.cansoAgent.service.targetport }}

--- a/canso-data-plane/canso-agent/values.yaml
+++ b/canso-data-plane/canso-agent/values.yaml
@@ -174,7 +174,7 @@ cansoAgent:
       pullPolicy: Always
       ## @param cansoAgent.deployment.image.tag Tag for the image
       ##
-      tag: v0.0.5-python-3.8-slim
+      tag: "sha256:5295215c13198ceb0e41025c472985fe568e07a7757b1bd9ea6a9f8a95545fd6"
     ## @section resources configuration
     resources:
       ## @section resources limits configuration

--- a/canso-data-plane/canso-airflow-jobs/Chart.yaml
+++ b/canso-data-plane/canso-airflow-jobs/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.7
+version: 0.1.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-aws-eks-superchart/README.md
+++ b/canso-data-plane/canso-aws-eks-superchart/README.md
@@ -135,25 +135,25 @@
 
 ### Jerry
 
-| Name                            | Description                                                            | Value                     |
-| ------------------------------- | ---------------------------------------------------------------------- | ------------------------- |
-| `jerry.enabled`                 | Flag to enable Jerry.                                                  | `true`                    |
-| `jerry.external_secret.enabled` | Flag to enable the creation of a secret in the same namespace as jerry | `true`                    |
-| `jerry.image.tag`               | Tag of the Jerry image.                                                | `v0.0.4-python-3.10-slim` |
-| `jerry.service.type`            | Type of the service for Jerry.                                         | `NodePort`                |
-| `jerry.service.port`            | Port of the service for Jerry.                                         | `3000`                    |
-| `jerry.readinessProbe.enabled`  | Flag to enable readiness probe for Jerry.                              | `false`                   |
-| `jerry.livenessProbe.enabled`   | Flag to enable liveness probe for Jerry.                               | `false`                   |
+| Name                            | Description                                                            | Value                                                                     |
+| ------------------------------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `jerry.enabled`                 | Flag to enable Jerry.                                                  | `true`                                                                    |
+| `jerry.external_secret.enabled` | Flag to enable the creation of a secret in the same namespace as jerry | `true`                                                                    |
+| `jerry.image.tag`               | Tag of the Jerry image.                                                | `sha256:a79046ebf4b32ec501e988210c804307bfda51f4d25a708f02550dcb058da3f3` |
+| `jerry.service.type`            | Type of the service for Jerry.                                         | `NodePort`                                                                |
+| `jerry.service.port`            | Port of the service for Jerry.                                         | `3000`                                                                    |
+| `jerry.readinessProbe.enabled`  | Flag to enable readiness probe for Jerry.                              | `false`                                                                   |
+| `jerry.livenessProbe.enabled`   | Flag to enable liveness probe for Jerry.                               | `false`                                                                   |
 
 ### Online Feature Service
 
-| Name                               | Description                                             | Value    |
-| ---------------------------------- | ------------------------------------------------------- | -------- |
-| `onlineFS.enabled`                 | Flag to enable Online Feature Store.                    | `true`   |
-| `onlineFS.external_secret.enabled` | Flag to enable the creation of an external secret       | `true`   |
-| `onlineFS.deployment.replicaCount` | Number of replicas for Online Feature Store deployment. | `1`      |
-| `onlineFS.deployment.image.tag`    | Tag of the Online Feature Store image.                  | `v0.0.1` |
-| `onlineFS.ingress.enabled`         | Flag to enable ingress for Online Feature Store.        | `false`  |
+| Name                               | Description                                             | Value                                                                     |
+| ---------------------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `onlineFS.enabled`                 | Flag to enable Online Feature Store.                    | `true`                                                                    |
+| `onlineFS.external_secret.enabled` | Flag to enable the creation of an external secret       | `true`                                                                    |
+| `onlineFS.deployment.replicaCount` | Number of replicas for Online Feature Store deployment. | `1`                                                                       |
+| `onlineFS.deployment.image.tag`    | Tag of the Online Feature Store image.                  | `sha256:220563b873f6c2e0c7ce063da6655e6059a69b47db0e93806df7b72e0f165bbd` |
+| `onlineFS.ingress.enabled`         | Flag to enable ingress for Online Feature Store.        | `false`                                                                   |
 
 ### Airflow Jobs
 

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
@@ -28,7 +28,7 @@ spec:
       source:
         repoURL: 'https://yugen-ai.github.io/canso-helm-charts'
         chart: canso-agent
-        targetRevision: 0.1.6
+        targetRevision: 0.1.7
         helm:
           values: |-
             config:

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-airflow-jobs.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-airflow-jobs.yaml
@@ -27,7 +27,7 @@ spec:
         namespace: {{ .Values.cansoAirflowJobs.namespace }}
       sources:
       - repoURL: 'https://yugen-ai.github.io/canso-helm-charts'
-        targetRevision: "0.1.2"
+        targetRevision: "0.1.3"
         chart: canso-airflow-jobs
         releaseName: canso-helm-charts/canso-airflow-jobs
         helm:

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/jerry.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/jerry.yaml
@@ -28,7 +28,7 @@ spec:
         namespace: airflow
       sources:
       - repoURL: 'https://yugen-ai.github.io/canso-helm-charts'
-        targetRevision: "0.0.4"
+        targetRevision: "0.0.5"
         chart: canso-workflow-orchestrator
         helm:
           releaseName: "jerry"

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/karpenter.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/karpenter.yaml
@@ -29,7 +29,7 @@ spec:
         server: 'https://kubernetes.default.svc'
       source:
         repoURL: https://yugen-ai.github.io/canso-helm-charts
-        targetRevision: 0.0.2
+        targetRevision: 0.0.3
         chart: canso-karpenter
         helm:
           releaseName: karpenter

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/online-fs.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/online-fs.yaml
@@ -27,7 +27,7 @@ spec:
         server: https://kubernetes.default.svc
       source:
         repoURL: 'https://yugen-ai.github.io/canso-helm-charts'
-        targetRevision: "0.0.3"
+        targetRevision: "0.0.4"
         chart: canso-online-feature-service
         helm:
           values: |

--- a/canso-data-plane/canso-aws-eks-superchart/values.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/values.yaml
@@ -361,7 +361,8 @@ jerry:
   image:
     ## @param jerry.image.tag Tag of the Jerry image.
     ##
-    tag: "v0.0.4-python-3.10-slim"
+    tag: "sha256:a79046ebf4b32ec501e988210c804307bfda51f4d25a708f02550dcb058da3f3"
+    # Reference - `image.tag` in `canso-data-plane/canso-workflow-orchestrator/values.yaml`
     
   ## @subsection jerry.service 
   service:
@@ -407,7 +408,8 @@ onlineFS:
     image:
       ## @param onlineFS.deployment.image.tag Tag of the Online Feature Store image.
       ##
-      tag: v0.0.1
+      tag: "sha256:220563b873f6c2e0c7ce063da6655e6059a69b47db0e93806df7b72e0f165bbd"
+      # Reference - `deployment.image.tag` in `canso-data-plane/canso-online-feature-service/values.yaml`
 
   ingress:
     ## @param onlineFS.ingress.enabled Flag to enable ingress for Online Feature Store.

--- a/canso-data-plane/canso-karpenter/Chart.yaml
+++ b/canso-data-plane/canso-karpenter/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: canso-karpenter
 description: A Helm chart for Kubernetes
 type: application
-version: 0.0.2
+version: 0.0.3
 appVersion: "0.0.1"
 dependencies:
   - name: karpenter

--- a/canso-data-plane/canso-karpenter/README.md
+++ b/canso-data-plane/canso-karpenter/README.md
@@ -21,15 +21,14 @@
 
 ### karpenter.strategy Rolling update configuration parameters.
 
-| Name                                      | Description                                                          | Value                     |
-| ----------------------------------------- | -------------------------------------------------------------------- | ------------------------- |
-| `karpenter.podLabels`                     | Additional labels for the Karpenter pod.                             | `{}`                      |
-| `karpenter.podAnnotations`                | Additional annotations for the Karpenter pod.                        | `{}`                      |
-| `karpenter.priorityClassName`             | PriorityClass name for the pod.                                      | `system-cluster-critical` |
-| `karpenter.terminationGracePeriodSeconds` | Override the default termination grace period for the pod.           | `nil`                     |
-| `karpenter.hostNetwork`                   | Bind the pod to the host network (required when using a custom CNI). | `false`                   |
-| `karpenter.dnsPolicy`                     | Configure the DNS Policy for the pod.                                | `Default`                 |
-| `karpenter.dnsConfig`                     | Configure DNS Config for the pod.                                    | `{}`                      |
+| Name                          | Description                                                          | Value                     |
+| ----------------------------- | -------------------------------------------------------------------- | ------------------------- |
+| `karpenter.podLabels`         | Additional labels for the Karpenter pod.                             | `{}`                      |
+| `karpenter.podAnnotations`    | Additional annotations for the Karpenter pod.                        | `{}`                      |
+| `karpenter.priorityClassName` | PriorityClass name for the pod.                                      | `system-cluster-critical` |
+| `karpenter.hostNetwork`       | Bind the pod to the host network (required when using a custom CNI). | `false`                   |
+| `karpenter.dnsPolicy`         | Configure the DNS Policy for the pod.                                | `Default`                 |
+| `karpenter.dnsConfig`         | Configure DNS Config for the pod.                                    | `{}`                      |
 
 ### karpenter.affinity Affinity rules for scheduling the pod.
 

--- a/canso-data-plane/canso-karpenter/values.yaml
+++ b/canso-data-plane/canso-karpenter/values.yaml
@@ -80,7 +80,7 @@ karpenter:
   ##
   priorityClassName: system-cluster-critical
 
-  ## @param karpenter.terminationGracePeriodSeconds Override the default termination grace period for the pod.
+  ## @skip karpenter.terminationGracePeriodSeconds Override the default termination grace period for the pod.
   ##
   terminationGracePeriodSeconds:
 

--- a/canso-data-plane/canso-online-feature-service/Chart.yaml
+++ b/canso-data-plane/canso-online-feature-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.3
+version: 0.0.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-online-feature-service/Chart.yaml
+++ b/canso-data-plane/canso-online-feature-service/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.0.3
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.1"
+appVersion: "v0.0.2-python-3.9.18-slim"

--- a/canso-data-plane/canso-online-feature-service/README.md
+++ b/canso-data-plane/canso-online-feature-service/README.md
@@ -31,13 +31,13 @@
 
 ### deployment.image 
 
-| Name                          | Description                                                    | Value                                    |
-| ----------------------------- | -------------------------------------------------------------- | ---------------------------------------- |
-| `deployment.image.repository` | The image repository                                           | `shaktimaanbot/feature-retrieval-server` |
-| `deployment.image.pullPolicy` | Image pull policy                                              | `IfNotPresent`                           |
-| `deployment.image.tag`        | Overrides the image tag whose default is the chart appVersion. | `v0.0.1`                                 |
-| `deployment.enableEnv`        | Enable the environment variables                               | `false`                                  |
-| `deployment.enableEnvSecrets` | Enable the environment variables from secrets                  | `false`                                  |
+| Name                          | Description                                                    | Value                                                                     |
+| ----------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `deployment.image.repository` | The image repository                                           | `shaktimaanbot/feature-retrieval-server-prod`                             |
+| `deployment.image.pullPolicy` | Image pull policy                                              | `IfNotPresent`                                                            |
+| `deployment.image.tag`        | Overrides the image tag whose default is the chart appVersion. | `sha256:220563b873f6c2e0c7ce063da6655e6059a69b47db0e93806df7b72e0f165bbd` |
+| `deployment.enableEnv`        | Enable the environment variables                               | `false`                                                                   |
+| `deployment.enableEnvSecrets` | Enable the environment variables from secrets                  | `false`                                                                   |
 
 ### autoscaling 
 

--- a/canso-data-plane/canso-online-feature-service/templates/_helpers.tpl
+++ b/canso-data-plane/canso-online-feature-service/templates/_helpers.tpl
@@ -60,3 +60,16 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the image path for the passed in image field
+Credits - https://blog.andyserver.com/2021/09/adding-image-digest-references-to-your-helm-charts/
+*/}}
+{{- define "online-feature-service.image" -}}
+{{- $tag := .tag -}}
+{{- if eq (substr 0 7 $tag) "sha256:" -}}
+{{- printf "%s@%s" .repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" .repository $tag -}}
+{{- end -}}
+{{- end -}}

--- a/canso-data-plane/canso-online-feature-service/templates/deployment.yaml
+++ b/canso-data-plane/canso-online-feature-service/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ include "online-feature-service.name" . }}
-        image: {{ .Values.deployment.image.repository }}:{{ .Values.deployment.image.tag }}
+        image: {{ include "online-feature-service.image" (dict "repository" .Values.deployment.image.repository "tag" (default .Chart.AppVersion .Values.deployment.image.tag)) }}
         ports:
         - containerPort: {{ .Values.service.targetport }}
         resources:

--- a/canso-data-plane/canso-online-feature-service/values.yaml
+++ b/canso-data-plane/canso-online-feature-service/values.yaml
@@ -62,11 +62,11 @@ deployment:
   ## @section deployment.image 
   image:
     ## @param deployment.image.repository The image repository
-    repository: shaktimaanbot/feature-retrieval-server
+    repository: shaktimaanbot/feature-retrieval-server-prod
     ## @param deployment.image.pullPolicy Image pull policy
     pullPolicy: IfNotPresent
     ## @param deployment.image.tag Overrides the image tag whose default is the chart appVersion.
-    tag: v0.0.1
+    tag: "sha256:220563b873f6c2e0c7ce063da6655e6059a69b47db0e93806df7b72e0f165bbd"
 
   ## @skip deployment.resources The resources requests and limits for the container.
   resources:

--- a/canso-data-plane/canso-workflow-orchestrator/Chart.yaml
+++ b/canso-data-plane/canso-workflow-orchestrator/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-workflow-orchestrator/Chart.yaml
+++ b/canso-data-plane/canso-workflow-orchestrator/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.0.4
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.0.1"
+appVersion: "v0.0.4-python-3.10-slim"

--- a/canso-data-plane/canso-workflow-orchestrator/README.md
+++ b/canso-data-plane/canso-workflow-orchestrator/README.md
@@ -10,11 +10,11 @@
 
 ### image
 
-| Name               | Description                                                   | Value                            |
-| ------------------ | ------------------------------------------------------------- | -------------------------------- |
-| `image.repository` | Image repository                                              | `shaktimaanbot/jerry-image-prod` |
-| `image.pullPolicy` | Image pull policy                                             | `Always`                         |
-| `image.tag`        | Overrides the image tag whose default is the chart appVersion | `v0.0.4-python-3.10-slim`        |
+| Name               | Description                                                              | Value                                                                     |
+| ------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| `image.repository` | Image repository                                                         | `shaktimaanbot/jerry-image-prod`                                          |
+| `image.pullPolicy` | Image pull policy                                                        | `Always`                                                                  |
+| `image.tag`        | Overrides the image tag/SHA digest whose default is the chart appVersion | `sha256:a79046ebf4b32ec501e988210c804307bfda51f4d25a708f02550dcb058da3f3` |
 
 ### external_secret
 

--- a/canso-data-plane/canso-workflow-orchestrator/templates/_helpers.tpl
+++ b/canso-data-plane/canso-workflow-orchestrator/templates/_helpers.tpl
@@ -49,3 +49,16 @@ Selector labels
 app.kubernetes.io/name: {{ include "helm-jerry.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Create the image path for the passed in image field
+Credits - https://blog.andyserver.com/2021/09/adding-image-digest-references-to-your-helm-charts/
+*/}}
+{{- define "helm-jerry.image" -}}
+{{- $tag := .tag -}}
+{{- if eq (substr 0 7 $tag) "sha256:" -}}
+{{- printf "%s@%s" .repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" .repository $tag -}}
+{{- end -}}
+{{- end -}}

--- a/canso-data-plane/canso-workflow-orchestrator/templates/deployment.yaml
+++ b/canso-data-plane/canso-workflow-orchestrator/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: {{ include "helm-jerry.image" (dict "repository" .Values.image.repository "tag" (default .Chart.AppVersion .Values.image.tag)) }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http

--- a/canso-data-plane/canso-workflow-orchestrator/values.yaml
+++ b/canso-data-plane/canso-workflow-orchestrator/values.yaml
@@ -20,9 +20,9 @@ image:
   ## @param image.pullPolicy Image pull policy
   ##
   pullPolicy: Always
-  ## @param image.tag Overrides the image tag whose default is the chart appVersion
+  ## @param image.tag Overrides the image tag/SHA digest whose default is the chart appVersion
   ##
-  tag: "v0.0.4-python-3.10-slim"
+  tag: "sha256:a79046ebf4b32ec501e988210c804307bfda51f4d25a708f02550dcb058da3f3"
 
 ## @section external_secret
 external_secret:


### PR DESCRIPTION
As we prep for release, we'll need to add SHA digests to image references in Helm charts/templates. We are going to use SHA digests instead of simple tags such as `latest` or `rc1` etc since they are floating in nature. This is [recommended by Helm as well](https://helm.sh/docs/chart_best_practices/pods/#images) & helps us to use our simpler Github trunk based workflows. Since SHA is immutable, we can merge PRs to main w/o impacting images running in Production unless we explicitly change the SHA in the tag.

### TODOs

- [x] Canso Orchestrator Chart
- [x] Canso Agent
- [x] Canso Superchart
- [x] Canso Online Feature Service


### Tests

Check how digests work on a simple nginx image by using SHA instead of tag.

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx-deployment
  labels:
    app: nginx
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
    spec:
      containers:
      - name: nginx
        image: nginx:stable-perl@sha256:ffc9db50b60859a80136ef2e4cfc891b0312e81c5af771cd4204b9b5a301c3f8
        ports:
        - containerPort: 80
      imagePullSecrets:
      - name: dockerhub-secret
```

```console
kubectl apply -f sha-poc-deployment.yaml
deployment.apps/nginx-deployment created
```

Check PODs to confirm that the image was pulled & POD is in a running state

```
(base) ➜  Codes-Github kubectl get pods
NAME                                READY   STATUS              RESTARTS   AGE
nginx-deployment-584dc5f464-8gfl2   0/1     ContainerCreating   0          5s
(base) ➜  Codes-Github kubectl get pods
NAME                                READY   STATUS              RESTARTS   AGE
nginx-deployment-584dc5f464-8gfl2   0/1     ContainerCreating   0          10s
(base) ➜  Codes-Github kubectl get pods
NAME                                READY   STATUS              RESTARTS   AGE
nginx-deployment-584dc5f464-8gfl2   0/1     ContainerCreating   0          13s
(base) ➜  Codes-Github kubectl get pods
NAME                                READY   STATUS    RESTARTS   AGE
nginx-deployment-584dc5f464-8gfl2   1/1     Running   0          23s
```


---

<details><summary><tt>Jerry - tag: ""</tt></summary>
<p>

```yaml
---
# Source: canso-workflow-orchestrator/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-canso-workflow-orchestrator
  namespace: default
  labels:
    helm.sh/chart: canso-workflow-orchestrator-0.0.4
    app.kubernetes.io/name: canso-workflow-orchestrator
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.0.4-python-3.10-slim"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: canso-workflow-orchestrator
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        app.kubernetes.io/name: canso-workflow-orchestrator
        app.kubernetes.io/instance: release-name
    spec:
      imagePullSecrets:
        - name: docker-secret-cred
      securityContext:
        {}
      volumes:
      - name: dags-folder
        persistentVolumeClaim:
          claimName: airflow-pvc   
      containers:
        - name: canso-workflow-orchestrator
          securityContext:
            {}
          image: shaktimaanbot/jerry-image-prod:v0.0.4-python-3.10-slim
          imagePullPolicy: Always
          ports:
            - name: http
              containerPort: 3000
              protocol: TCP
          volumeMounts:
          - name: dags-folder
            mountPath: /opt/airflow/dags
          command: ["/bin/sh", "-c", "cp -r jerry/ dags/ && mkdir -p dags/dag_properties/ && tail -f /dev/null"]
          resources:
            {}
---
# Source: canso-workflow-orchestrator/templates/external-secrets.yaml
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: canso-workflow-orchestrator-es
  namespace: default
spec:
  refreshInterval: 1m
  secretStoreRef:
    name: secretstore-by-role
    kind: ClusterSecretStore
  target:
    name: docker-secret-cred 
    template:
      type: kubernetes.io/dockerconfigjson 
  data:
  - secretKey: .dockerconfigjson 
    remoteRef:
      key: canso/dockerhub 
      property: dockerhub
---
# Source: canso-workflow-orchestrator/templates/tests/test-connection.yaml
apiVersion: v1
kind: Pod
metadata:
  name: "release-name-canso-workflow-orchestrator-test-connection"
  labels:
    helm.sh/chart: canso-workflow-orchestrator-0.0.4
    app.kubernetes.io/name: canso-workflow-orchestrator
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.0.4-python-3.10-slim"
    app.kubernetes.io/managed-by: Helm
  annotations:
    "helm.sh/hook": test-success
spec:
  containers:
    - name: wget
      image: busybox
      command: ['wget']
      args: ['release-name-canso-workflow-orchestrator:3000']
  restartPolicy: Never
```

</p>
</details> 

<details><summary><tt>Jerry - tag: "sha256:a7904xxx"</tt></summary>
<p>

```yaml
---
# Source: canso-workflow-orchestrator/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-canso-workflow-orchestrator
  namespace: default
  labels:
    helm.sh/chart: canso-workflow-orchestrator-0.0.4
    app.kubernetes.io/name: canso-workflow-orchestrator
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.0.4-python-3.10-slim"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: canso-workflow-orchestrator
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        app.kubernetes.io/name: canso-workflow-orchestrator
        app.kubernetes.io/instance: release-name
    spec:
      imagePullSecrets:
        - name: docker-secret-cred
      securityContext:
        {}
      volumes:
      - name: dags-folder
        persistentVolumeClaim:
          claimName: airflow-pvc   
      containers:
        - name: canso-workflow-orchestrator
          securityContext:
            {}
          image: shaktimaanbot/jerry-image-prod@sha256:a79046ebf4b32ec501e988210c804307bfda51f4d25a708f02550dcb058da3f3
          imagePullPolicy: Always
          ports:
            - name: http
              containerPort: 3000
              protocol: TCP
          volumeMounts:
          - name: dags-folder
            mountPath: /opt/airflow/dags
          command: ["/bin/sh", "-c", "cp -r jerry/ dags/ && mkdir -p dags/dag_properties/ && tail -f /dev/null"]
          resources:
            {}
---
# Source: canso-workflow-orchestrator/templates/external-secrets.yaml
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: canso-workflow-orchestrator-es
  namespace: default
spec:
  refreshInterval: 1m
  secretStoreRef:
    name: secretstore-by-role
    kind: ClusterSecretStore
  target:
    name: docker-secret-cred 
    template:
      type: kubernetes.io/dockerconfigjson 
  data:
  - secretKey: .dockerconfigjson 
    remoteRef:
      key: canso/dockerhub 
      property: dockerhub
---
# Source: canso-workflow-orchestrator/templates/tests/test-connection.yaml
apiVersion: v1
kind: Pod
metadata:
  name: "release-name-canso-workflow-orchestrator-test-connection"
  labels:
    helm.sh/chart: canso-workflow-orchestrator-0.0.4
    app.kubernetes.io/name: canso-workflow-orchestrator
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "v0.0.4-python-3.10-slim"
    app.kubernetes.io/managed-by: Helm
  annotations:
    "helm.sh/hook": test-success
spec:
  containers:
    - name: wget
      image: busybox
      command: ['wget']
      args: ['release-name-canso-workflow-orchestrator:3000']
  restartPolicy: Never
```

</p>
</details> 