### PR TITLE
[Issue-30]Adding default s3 connection in airflow appset

### DIFF
--- a/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.8
+version: 0.1.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/airflow.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/airflow.yaml
@@ -83,6 +83,10 @@ spec:
         helm:
           values: |
             airflow:
+              connections:
+                - id: aws_default
+                  type: s3
+                  description: Default AWS S3 connection
               users:
                 - username: {{ .Values.airflow.user.username }}
                   password: ${AIRFLOW_PASSWORD}


### PR DESCRIPTION
### Description

This PR adds a default AWS S3 connection named aws_default to our Airflow Helm chart configuration. 
This connection is set up with empty credentials, filled with actual credentials by the role_arn provided in the helm chart.

This solves the issue - https://github.com/Yugen-ai/canso-helm-charts/issues/30

### Testing

airflow-webserver-pod

```
mishrasandeep@Sandeeps-MacBook-Pro ~ % kubectl exec -it airflow-web-6bd56bc9c6-2nhwr -n airflow -- env | grep AWS
Defaulted container "airflow-web" out of: airflow-web, check-db (init), wait-for-db-migrations (init)
AWS_STS_REGIONAL_ENDPOINTS=regional
AWS_REGION=***
AWS_DEFAULT_REGION=***
AWS_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/eks.amazonaws.com/serviceaccount/token
AWS_ROLE_ARN=arn:aws:iam::***:role/airflow-canso-dataplane-prod-irsa-role
```

Airlfow connections added-

![image](https://github.com/user-attachments/assets/531cb4cc-24ac-4888-8301-83fd580bab70)


The logs are available on the Airflow UI post these updates.
