### PR TITLE
[NOJIRA] Adding canso-ai-agent helm chart for deploying ai agents - RC1

### DIFF
--- a/canso-data-plane/canso-ai-agent/Chart.yaml
+++ b/canso-data-plane/canso-ai-agent/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: canso-ai-agent
+description: A Helm chart for deploying AI agent services
+type: application
+version: 0.1.0-rc0
+appVersion: "0.0.1"

--- a/canso-data-plane/canso-ai-agent/README.md
+++ b/canso-data-plane/canso-ai-agent/README.md
@@ -1,0 +1,58 @@
+⚠️ **CAUTION: This chart is currently in development and not ready for production use.** ⚠️
+
+This Helm chart deploys an AI agent service to Kubernetes. It is currently in an alpha state and may contain bugs or incomplete features. Use at your own risk in development and testing environments only.
+
+## Parameters
+
+### Image parameters
+
+| Name               | Description                                                                              | Value          |
+| ------------------ | ---------------------------------------------------------------------------------------- | -------------- |
+| `image.repository` | Image repository                                                                         | `repo/image`   |
+| `image.pullPolicy` | Image pull policy                                                                        | `IfNotPresent` |
+| `image.tag`        | Image tag (immutable tags are recommended)                                               | `""`           |
+| `nameOverride`     | String to partially override ai-agent.fullname template (will maintain the release name) | `""`           |
+| `fullnameOverride` | String to fully override ai-agent.fullname template                                      | `""`           |
+
+### Service parameters
+
+| Name           | Description             | Value      |
+| -------------- | ----------------------- | ---------- |
+| `service.type` | Kubernetes Service type | `NodePort` |
+| `service.port` | Service port            | `80`       |
+
+### Autoscaling parameters
+
+| Name                                                        | Description                                | Value         |
+| ----------------------------------------------------------- | ------------------------------------------ | ------------- |
+| `autoscaling.enabled`                                       | Enable autoscaling for ai-agent deployment | `true`        |
+| `autoscaling.minReplicas`                                   | Minimum number of replicas to scale back   | `1`           |
+| `autoscaling.maxReplicas`                                   | Maximum number of replicas to scale out    | `5`           |
+| `autoscaling.metrics[0].type`                               | Type of metric to use for scaling          | `Resource`    |
+| `autoscaling.metrics[0].resource.name`                      | Name of the resource to monitor            | `memory`      |
+| `autoscaling.metrics[0].resource.target.type`               | Type of scaling target                     | `Utilization` |
+| `autoscaling.metrics[0].resource.target.averageUtilization` | Target average utilization percentage      | `80`          |
+
+### Resource Management
+
+| Name                 | Description                                        | Value |
+| -------------------- | -------------------------------------------------- | ----- |
+| `resources.limits`   | The resources limits for the ai-agent container    | `{}`  |
+| `resources.requests` | The requested resources for the ai-agent container | `{}`  |
+
+### Liveness and Readiness Probes
+
+| Name                                 | Description                              | Value   |
+| ------------------------------------ | ---------------------------------------- | ------- |
+| `livenessProbe.enabled`              | Enable livenessProbe                     | `false` |
+| `livenessProbe.initialDelaySeconds`  | Initial delay seconds for livenessProbe  | `10`    |
+| `livenessProbe.periodSeconds`        | Period seconds for livenessProbe         | `10`    |
+| `livenessProbe.timeoutSeconds`       | Timeout seconds for livenessProbe        | `5`     |
+| `livenessProbe.failureThreshold`     | Failure threshold for livenessProbe      | `3`     |
+| `livenessProbe.successThreshold`     | Success threshold for livenessProbe      | `1`     |
+| `readinessProbe.enabled`             | Enable readinessProbe                    | `false` |
+| `readinessProbe.initialDelaySeconds` | Initial delay seconds for readinessProbe | `5`     |
+| `readinessProbe.periodSeconds`       | Period seconds for readinessProbe        | `10`    |
+| `readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe       | `5`     |
+| `readinessProbe.failureThreshold`    | Failure threshold for readinessProbe     | `3`     |
+| `readinessProbe.successThreshold`    | Success threshold for readinessProbe     | `1`     |

--- a/canso-data-plane/canso-ai-agent/templates/NOTES.txt
+++ b/canso-data-plane/canso-ai-agent/templates/NOTES.txt
@@ -1,0 +1,5 @@
+WARNING: Development Version
+
+You've installed the development version of the AI Agent chart. This version is not intended for production use and may contain bugs or incomplete features. Please use caution and report any issues to:
+
+https://github.com/Yugen-ai/canso-helm-charts/issues

--- a/canso-data-plane/canso-ai-agent/templates/_helpers.tpl
+++ b/canso-data-plane/canso-ai-agent/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "ai-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "ai-agent.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "ai-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "ai-agent.labels" -}}
+helm.sh/chart: {{ include "ai-agent.chart" . }}
+{{ include "ai-agent.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "ai-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "ai-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/canso-data-plane/canso-ai-agent/templates/deployments.yaml
+++ b/canso-data-plane/canso-ai-agent/templates/deployments.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "ai-agent.fullname" . }}
+  labels:
+    {{- include "ai-agent.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "ai-agent.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "ai-agent.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          {{- if .Values.resources }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          {{- if .Values.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          {{- end }}

--- a/canso-data-plane/canso-ai-agent/templates/hpa.yaml
+++ b/canso-data-plane/canso-ai-agent/templates/hpa.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "ai-agent.fullname" . }}
+  labels:
+    {{- include "ai-agent.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "ai-agent.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- toYaml .Values.autoscaling.metrics | nindent 4 }}
+{{- end }}
+

--- a/canso-data-plane/canso-ai-agent/templates/required.yaml
+++ b/canso-data-plane/canso-ai-agent/templates/required.yaml
@@ -1,0 +1,7 @@
+## Mandatory values for the Canso Ai Agent Helm. If not provided, helm will fail with a 
+## `Error: execution error at ...` message.
+## The goal of this file to be a central place to have a single source of truth for
+## all values mandatorily needed by the Helm.
+
+
+{{- $_ := required "image.repository is a required value" .Values.image.repository}}

--- a/canso-data-plane/canso-ai-agent/templates/service.yaml
+++ b/canso-data-plane/canso-ai-agent/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "ai-agent.fullname" . }}
+  labels:
+    {{- include "ai-agent.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "ai-agent.selectorLabels" . | nindent 4 }}
+

--- a/canso-data-plane/canso-ai-agent/values.yaml
+++ b/canso-data-plane/canso-ai-agent/values.yaml
@@ -1,0 +1,89 @@
+# values.yaml
+
+## @param replicaCount Number of replicas to deploy
+replicaCount: 1
+
+## @section Image parameters
+image:
+  ## @param image.repository Image repository
+  repository: repo/image
+  ## @param image.pullPolicy Image pull policy
+  pullPolicy: IfNotPresent
+  ## @param image.tag Image tag (immutable tags are recommended)
+  tag: ""
+
+## @param nameOverride String to partially override ai-agent.fullname template (will maintain the release name)
+nameOverride: ""
+## @param fullnameOverride String to fully override ai-agent.fullname template
+fullnameOverride: ""
+
+## @section Service parameters
+service:
+  ## @param service.type Kubernetes Service type
+  type: NodePort
+  ## @param service.port Service port
+  port: 80
+
+## @section Autoscaling parameters
+autoscaling:
+  ## @param autoscaling.enabled Enable autoscaling for ai-agent deployment
+  enabled: true
+  ## @param autoscaling.minReplicas Minimum number of replicas to scale back
+  minReplicas: 1
+  ## @param autoscaling.maxReplicas Maximum number of replicas to scale out
+  maxReplicas: 5
+  ## @subsection autoscaling.metrics Metrics to use for scaling (only type Resource is supported)
+  metrics:
+    ## @param autoscaling.metrics[0].type Type of metric to use for scaling
+    - type: Resource
+      ## @subsection autoscaling.metrics[0].resource Resource metrics to use for scaling
+      resource:
+        ## @param autoscaling.metrics[0].resource.name Name of the resource to monitor
+        name: memory
+        ## @subsection autoscaling.metrics[0].resource.target Target for the resource metric
+        target:
+          ## @param autoscaling.metrics[0].resource.target.type Type of scaling target
+          type: Utilization
+          ## @param autoscaling.metrics[0].resource.target.averageUtilization Target average utilization percentage
+          averageUtilization: 80
+
+## @section Resource Management
+resources:
+  ## @param resources.limits The resources limits for the ai-agent container
+  limits: {}
+    # cpu: 100m
+    # memory: 128Mi
+  ## @param resources.requests The requested resources for the ai-agent container
+  requests: {}
+    # cpu: 100m
+    # memory: 128Mi
+
+## @section Liveness and Readiness Probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
+livenessProbe:
+  ## @param livenessProbe.enabled Enable livenessProbe
+  enabled: false
+  ## @param livenessProbe.initialDelaySeconds Initial delay seconds for livenessProbe
+  initialDelaySeconds: 10
+  ## @param livenessProbe.periodSeconds Period seconds for livenessProbe
+  periodSeconds: 10
+  ## @param livenessProbe.timeoutSeconds Timeout seconds for livenessProbe
+  timeoutSeconds: 5
+  ## @param livenessProbe.failureThreshold Failure threshold for livenessProbe
+  failureThreshold: 3
+  ## @param livenessProbe.successThreshold Success threshold for livenessProbe
+  successThreshold: 1
+
+readinessProbe:
+  ## @param readinessProbe.enabled Enable readinessProbe
+  enabled: false
+  ## @param readinessProbe.initialDelaySeconds Initial delay seconds for readinessProbe
+  initialDelaySeconds: 5
+  ## @param readinessProbe.periodSeconds Period seconds for readinessProbe
+  periodSeconds: 10
+  ## @param readinessProbe.timeoutSeconds Timeout seconds for readinessProbe
+  timeoutSeconds: 5
+  ## @param readinessProbe.failureThreshold Failure threshold for readinessProbe
+  failureThreshold: 3
+  ## @param readinessProbe.successThreshold Success threshold for readinessProbe
+  successThreshold: 1


### PR DESCRIPTION
### Description

This PR introduces a new Helm chart for deploying AI agent services to Kubernetes clusters. The chart is designed to be flexible, allowing users to easily configure and deploy AI agents with various settings

Features
 - Configurable deployment with customizable number of replicas
 - Horizontal Pod Autoscaler (HPA) for automatic scaling based on CPU or memory usage
 - Customizable resource requests and limits
 - Configurable liveness and readiness probes

Development indicators - 
 - Chart version - 0.0.1-rc0
 - NOTES.txt -  warning on installation
 - README.md

### Testing

tested on EKS cluster- 

**command** - 

```
helm install ai-agent-helm canso-data-plane/canso-ai-agent -n ai-agent-helm --create-namespace
```

**output** - 

```
NAME: ai-agent-helm
LAST DEPLOYED: Fri Aug  9 17:50:46 2024
NAMESPACE: ai-agent-helm
STATUS: deployed
REVISION: 1
TEST SUITE: None
NOTES:
WARNING: Development Version

You've installed the development version of the AI Agent chart. This version is not intended for production use and may contain bugs or incomplete features. Please use caution and report any issues to:

https://github.com/Yugen-ai/canso-helm-charts/issues
```


**resources** -

`kubectl get all -n ai-agent-helm`

```
NAME                                                READY   STATUS    RESTARTS   AGE
pod/ai-agent-helm-canso-ai-agent-6b6c75c78c-wvf89   1/1     Running   0          19m

NAME                                   TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)        AGE
service/ai-agent-helm-canso-ai-agent   NodePort   172.20.181.80   <none>        80:32464/TCP   19m

NAME                                           READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/ai-agent-helm-canso-ai-agent   1/1     1            1           19m

NAME                                                      DESIRED   CURRENT   READY   AGE
replicaset.apps/ai-agent-helm-canso-ai-agent-6b6c75c78c   1         1         1       19m

NAME                                                               REFERENCE                                 TARGETS         MINPODS   MAXPODS   REPLICAS   AGE
horizontalpodautoscaler.autoscaling/ai-agent-helm-canso-ai-agent   Deployment/ai-agent-helm-canso-ai-agent   <unknown>/80%   1         5         1          19m
```



### Notes -

1. ServiceAccount with orsa role name to be added in a future release