### PR TITLE
[NOJIRA] Updating spark operator AppSet to use chart keyword instead of path

### DIFF
--- a/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.9
+version: 0.1.10
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/spark-operator.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/spark-operator.yaml
@@ -51,9 +51,9 @@ spec:
         namespace: spark-operator
         server: https://kubernetes.default.svc
       source:
-        repoURL: https://github.com/kubeflow/spark-operator
-        path: charts/spark-operator-chart
-        targetRevision:
+        repoURL: https://kubeflow.github.io/spark-operator/
+        chart: spark-operator
+        targetRevision: 1.4.6
         helm:
           values: |-
             sparkJobNamespaces:


### PR DESCRIPTION
### Description

The SparkApplication currently created are facing issues due to an rc realease of the spark-operator helm chart - https://github.com/kubeflow/spark-operator/releases

The pod for the sparkApplication does not get created and the status for the Applications are not available.

This PR - 
1. Changes the Appset source to use the helm chart and version instead of github source and path
2. The helm chart source is updated to `https://kubeflow.github.io/spark-operator/` where the chart is now being served and the target revision is set to `1.4.6` which was the last stable version


**This change affects all the spark streaming Applications running in the dataplane.**

### Testing

The Appset has been tested in the `data-plane` cluster

![image](https://github.com/user-attachments/assets/f1388879-9b91-4c35-8cac-df1a2ea5ba8d)

lastest sparkApplication run:

`kubectl get sparkapplications -n spark-streaming-jobs`

```
NAME                                        STATUS    ATTEMPTS   START                  FINISH       AGE
employee-3-month-salary-sum-22-aug-v1-626   RUNNING   2          2024-08-22T13:00:43Z   <no value>   5m9s
```


### Deployment

1. Merge the PR
2. Check the release version `0.1.10` is released successfully
3. Subsequent installations of dataplane to be done with version 0.1.10

### Rollback Strategy

1. The PR will be reverted and the version 0.1.10 will be deleted manually from the releases and index.yaml.