### PR TITLE
[NOJIRA] Update ExternalSecret values for canso-agent in superchart

### DIFF
--- a/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
@@ -55,6 +55,16 @@ spec:
               affinity:
                 {{ toYaml . | nindent 12 }}
               {{- end }}
+              external_secret:
+                enabled: true
+                target_secret_name: {{ (index .Values.canso.imagePullSecrets 0).targetName }}
+                target_secret_type: {{ (index .Values.canso.imagePullSecrets 0).targetType }}
+                target_secret_name_key: {{ (index .Values.canso.imagePullSecrets 0).secretKey }}
+                aws_secret_name: {{ (index .Values.canso.imagePullSecrets 0).remoteRefKey }}
+                aws_secret_key: {{ (index .Values.canso.imagePullSecrets 0).remoteRefProperty }}
+              secretStoreRef:
+                name: {{ (index .Values.canso.imagePullSecrets 0).clusterSecretRole }}
+                kind: ClusterSecretStore
       syncPolicy:
         automated:
           prune: true

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/required.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/required.yaml
@@ -7,3 +7,7 @@
 {{- $_ := required "roleArn is a required value" .Values.airflow.roleArn}}
 {{- $_ := required "pvc.Name is a required value" .Values.airflow.pvc.name}}
 {{- $_ := required "password is a required value" .Values.airflow.user.password}}
+{{- $_ := required "deployment_sqs_url is a required value" .Values.cansoControlPlane.deployment_sqs_url}}
+{{- $_ := required "notification_sqs_url is a required value" .Values.cansoControlPlane.notification_sqs_url}}
+{{- $_ := required "sqs_region is a required value" .Values.cansoControlPlane.sqs_region}}
+{{- $_ := required "control_plane_role_arn is a required value" .Values.cansoControlPlane.control_plane_role_arn}}

--- a/canso-data-plane/canso-aws-eks-superchart/values.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/values.yaml
@@ -107,7 +107,7 @@ canso:
   imagePullSecrets:
     - name: canso-image-pull-secrets
       secretKey: .dockerconfigjson # key of the kubernetes secret
-      remoteRefKey: canso/dockerhub # name of AWS secret
+      remoteRefKey: canso-dockerhub-credentials # name of AWS secret
       remoteRefProperty: dockerhub # key of the secret in secrets manager
       targetName: docker-secret-cred # name of kubernetes secret
       targetType: kubernetes.io/dockerconfigjson


### PR DESCRIPTION
### Description

The Superchart fails to install the canso agent helm chart if the secret name is changed on the dataplane. The changes fix this issue.

This PR-
1. Adds values from super chart values.yaml to override canso-agent default values.
2. Adds canso agent `cansoControlPlane` values to required.yaml
3. Update superchart version in Chart.yaml

### Testing

command-

`helm template . &> template.txt`
 
output - 

```
---
# Source: canso-aws-eks-superchart/templates/aws/canso-agent.yaml
apiVersion: argoproj.io/v1alpha1
kind: ApplicationSet
metadata:
  name: canso-agent
  namespace: argocd
  annotations:
    argocd.argoproj.io/sync-wave: "5"
  labels:
    canso.ai/product-component: "canso-apps"
    canso.ai/part-of: "superchart"
    canso.ai/infra-component: "dataplane-agents"
    canso.ai/infra-tag: "1002"
spec:
  generators:
  - list:
      elements:
      - cluster: 
        url: https://kubernetes.default.svc
  template:
    metadata:
      name: canso-agent
    spec:
      project: canso-appsets
      destination:
        namespace: canso-dataplane
        server: https://kubernetes.default.svc
      source:
        repoURL: 'https://yugen-ai.github.io/canso-helm-charts'
        chart: canso-agent
        targetRevision: 0.1.8
        helm:
          values: |-
            config:
              tenantName: 
              tenantID: 
              deployment_sqs_url: demo_url.com
              notification_sqs_url: demo_url.com
              sqs_region: demo_region  
              control_plane_role_arn: demo_cp_arn
            airflowDeploySecret:
              username: admin
              password: admin#airflow@123
            cansoAgent:
              enabled: true
              serviceAccount:
                create: true
                annotations:
                  eks.amazonaws.com/role-arn: 
              external_secret:
                enabled: true
                target_secret_name: docker-secret-cred
                target_secret_type: kubernetes.io/dockerconfigjson
                target_secret_name_key: .dockerconfigjson
                aws_secret_name: canso-dockerhub-credentials
                aws_secret_key: dockerhub
              secretStoreRef:
                name: secretstore-by-role
                kind: ClusterSecretStore
      syncPolicy:
        automated:
          prune: true
          selfHeal: true
        syncOptions:
          - CreateNamespace=true
          - ServerSideApply=true
---
```


### Deployment

1. Merge the PR
2. Check the Github Action successfully packages and releases the latest version
3. Run `helm upgrade` command on the sample dataplane cluster with the latest version

### Rollback

1. Revert the PR
2. Keep the version as the latest `0.1.11` itself so the the latest chart release is updated with reverted code. 
3. Run `helm upgrade` on the sample dataplane cluster