### PR TITLE
Online Feature Service, Agent & Superchart now reference app versions that point to python 3.13-slim base image for better security posture

### DIFF
--- a/canso-data-plane/canso-agent/Chart.yaml
+++ b/canso-data-plane/canso-agent/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.0.6-python-3.8-slim"
+appVersion: "v0.0.7-python-3.13-slim"

--- a/canso-data-plane/canso-agent/README.md
+++ b/canso-data-plane/canso-agent/README.md
@@ -88,7 +88,7 @@
 | ---------------------------------------- | ------------------------- | ------------------------------------------------------------------------- |
 | `cansoAgent.deployment.image.repository` | repository for the image  | `shaktimaanbot/dev-agent-image`                                           |
 | `cansoAgent.deployment.image.pullPolicy` | Pull policy for the image | `Always`                                                                  |
-| `cansoAgent.deployment.image.tag`        | Tag for the image         | `sha256:4d61db5d64cfa7e4c3cf8fbf8a4d2070b3a67926446e0bfa5de6f149af3baf00` |
+| `cansoAgent.deployment.image.tag`        | Tag for the image         | `sha256:b86b41acbb3961ebf59e5e6f1ce34997da54c73361ba02b657a1123e85cf5e85` |
 
 ### resources configuration
 
@@ -120,7 +120,7 @@
 | --------------------------------------------- | ------------------------- | ------------------------------------------------------------------------- |
 | `cansoAgent.proxyDeployment.image.repository` | repository for the image  | `shaktimaanbot/dev-agent-image`                                           |
 | `cansoAgent.proxyDeployment.image.pullPolicy` | Pull policy for the image | `Always`                                                                  |
-| `cansoAgent.proxyDeployment.image.tag`        | Tag for the image         | `sha256:24bd248684c38b9f7b7edce4fac91f052c5e4435f088d1b169be30a93ff5e2b5` |
+| `cansoAgent.proxyDeployment.image.tag`        | Tag for the image         | `sha256:b86b41acbb3961ebf59e5e6f1ce34997da54c73361ba02b657a1123e85cf5e85` |
 
 ### resources configuration
 

--- a/canso-data-plane/canso-agent/values.yaml
+++ b/canso-data-plane/canso-agent/values.yaml
@@ -182,7 +182,7 @@ cansoAgent:
       pullPolicy: Always
       ## @param cansoAgent.deployment.image.tag Tag for the image
       ##
-      tag: "sha256:4d61db5d64cfa7e4c3cf8fbf8a4d2070b3a67926446e0bfa5de6f149af3baf00"
+      tag: "sha256:b86b41acbb3961ebf59e5e6f1ce34997da54c73361ba02b657a1123e85cf5e85"
     ## @section resources configuration
     resources:
       ## @section resources limits configuration
@@ -237,7 +237,9 @@ cansoAgent:
       pullPolicy: Always
       ## @param cansoAgent.proxyDeployment.image.tag Tag for the image
       ##
-      tag: "sha256:24bd248684c38b9f7b7edce4fac91f052c5e4435f088d1b169be30a93ff5e2b5"
+      # Do not rely on the chart's `appVersion` since the proxy and the core agent
+      # are on different positions in the semver progression.
+      tag: "sha256:b86b41acbb3961ebf59e5e6f1ce34997da54c73361ba02b657a1123e85cf5e85"
     ## @section resources configuration
     resources:
       ## @section resources limits configuration

--- a/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.14
+version: 0.1.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-aws-eks-superchart/README.md
+++ b/canso-data-plane/canso-aws-eks-superchart/README.md
@@ -151,7 +151,7 @@
 | `onlineFS.enabled`                 | Flag to enable Online Feature Store.                    | `true`                                                                    |
 | `onlineFS.external_secret.enabled` | Flag to enable the creation of an external secret       | `true`                                                                    |
 | `onlineFS.deployment.replicaCount` | Number of replicas for Online Feature Store deployment. | `1`                                                                       |
-| `onlineFS.deployment.image.tag`    | Tag of the Online Feature Store image.                  | `sha256:220563b873f6c2e0c7ce063da6655e6059a69b47db0e93806df7b72e0f165bbd` |
+| `onlineFS.deployment.image.tag`    | Tag of the Online Feature Store image.                  | `sha256:3bcbcf0dd673784e63f4b68548c976f915c22f046e3966d654484a6235a892fd` |
 | `onlineFS.ingress.enabled`         | Flag to enable ingress for Online Feature Store.        | `false`                                                                   |
 
 ### Airflow Jobs

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
@@ -28,7 +28,7 @@ spec:
       source:
         repoURL: 'https://yugen-ai.github.io/canso-helm-charts'
         chart: canso-agent
-        targetRevision: 0.1.10
+        targetRevision: 0.1.11 # Canso Agent chart version
         helm:
           values: |-
             config:

--- a/canso-data-plane/canso-aws-eks-superchart/values.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/values.yaml
@@ -416,7 +416,7 @@ onlineFS:
     image:
       ## @param onlineFS.deployment.image.tag Tag of the Online Feature Store image.
       ##
-      tag: "sha256:220563b873f6c2e0c7ce063da6655e6059a69b47db0e93806df7b72e0f165bbd"
+      tag: "sha256:3bcbcf0dd673784e63f4b68548c976f915c22f046e3966d654484a6235a892fd"
       # Reference - `deployment.image.tag` in `canso-data-plane/canso-online-feature-service/values.yaml`
 
   ingress:

--- a/canso-data-plane/canso-online-feature-service/Chart.yaml
+++ b/canso-data-plane/canso-online-feature-service/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.0.2-python-3.9.18-slim"
+appVersion: "v0.0.3-python-3.13-slim"

--- a/canso-data-plane/canso-online-feature-service/README.md
+++ b/canso-data-plane/canso-online-feature-service/README.md
@@ -35,7 +35,7 @@
 | ----------------------------- | -------------------------------------------------------------- | ------------------------------------------------------------------------- |
 | `deployment.image.repository` | The image repository                                           | `shaktimaanbot/feature-retrieval-server-prod`                             |
 | `deployment.image.pullPolicy` | Image pull policy                                              | `IfNotPresent`                                                            |
-| `deployment.image.tag`        | Overrides the image tag whose default is the chart appVersion. | `sha256:220563b873f6c2e0c7ce063da6655e6059a69b47db0e93806df7b72e0f165bbd` |
+| `deployment.image.tag`        | Overrides the image tag whose default is the chart appVersion. | `sha256:3bcbcf0dd673784e63f4b68548c976f915c22f046e3966d654484a6235a892fd` |
 | `deployment.enableEnv`        | Enable the environment variables                               | `false`                                                                   |
 | `deployment.enableEnvSecrets` | Enable the environment variables from secrets                  | `false`                                                                   |
 

--- a/canso-data-plane/canso-online-feature-service/values.yaml
+++ b/canso-data-plane/canso-online-feature-service/values.yaml
@@ -66,7 +66,7 @@ deployment:
     ## @param deployment.image.pullPolicy Image pull policy
     pullPolicy: IfNotPresent
     ## @param deployment.image.tag Overrides the image tag whose default is the chart appVersion.
-    tag: "sha256:220563b873f6c2e0c7ce063da6655e6059a69b47db0e93806df7b72e0f165bbd"
+    tag: "sha256:3bcbcf0dd673784e63f4b68548c976f915c22f046e3966d654484a6235a892fd"
 
   ## @skip deployment.resources The resources requests and limits for the container.
   resources:


### PR DESCRIPTION
## Description

Based on Synk recommendations, we're now using python 3.13 slim as the base image for all our services/applications. Pursuant to the image upgrade, we're making a new helm release as well.

- https://github.com/Yugen-ai/platform-services/pull/55

### Deployment Plan

See https://github.com/Yugen-ai/platform-services/pull/55#issuecomment-2436285298

cc @Yugen-ai/platform-engineering 