### PR TITLE
Update dev agent image tag to latest

### DIFF
--- a/canso-data-plane/canso-agent/Chart.yaml
+++ b/canso-data-plane/canso-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.11
+version: 0.1.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-agent/Chart.yaml
+++ b/canso-data-plane/canso-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.10
+version: 0.1.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-agent/README.md
+++ b/canso-data-plane/canso-agent/README.md
@@ -88,7 +88,7 @@
 | ---------------------------------------- | ------------------------- | ------------------------------------------------------------------------- |
 | `cansoAgent.deployment.image.repository` | repository for the image  | `shaktimaanbot/dev-agent-image`                                           |
 | `cansoAgent.deployment.image.pullPolicy` | Pull policy for the image | `Always`                                                                  |
-| `cansoAgent.deployment.image.tag`        | Tag for the image         | `sha256:b86b41acbb3961ebf59e5e6f1ce34997da54c73361ba02b657a1123e85cf5e85` |
+| `cansoAgent.deployment.image.tag`        | Tag for the image         | `sha256:21a5f89c583b9a73c152110b87840ed408f799e1193efd0c4d1548e8582ff5f9` |
 
 ### resources configuration
 
@@ -120,7 +120,7 @@
 | --------------------------------------------- | ------------------------- | ------------------------------------------------------------------------- |
 | `cansoAgent.proxyDeployment.image.repository` | repository for the image  | `shaktimaanbot/dev-agent-image`                                           |
 | `cansoAgent.proxyDeployment.image.pullPolicy` | Pull policy for the image | `Always`                                                                  |
-| `cansoAgent.proxyDeployment.image.tag`        | Tag for the image         | `sha256:b86b41acbb3961ebf59e5e6f1ce34997da54c73361ba02b657a1123e85cf5e85` |
+| `cansoAgent.proxyDeployment.image.tag`        | Tag for the image         | `sha256:bad8eb8fe5561d17773eeaef041ac7f0ec478d7b89115a3d76109804c24793bc` |
 
 ### resources configuration
 

--- a/canso-data-plane/canso-agent/values.yaml
+++ b/canso-data-plane/canso-agent/values.yaml
@@ -237,7 +237,6 @@ cansoAgent:
       pullPolicy: Always
       ## @param cansoAgent.proxyDeployment.image.tag Tag for the image
       ##
-      
       # Do not rely on the chart's `appVersion` since the proxy and the core agent
       # are on different positions in the semver progression.
       tag: "sha256:bad8eb8fe5561d17773eeaef041ac7f0ec478d7b89115a3d76109804c24793bc"

--- a/canso-data-plane/canso-agent/values.yaml
+++ b/canso-data-plane/canso-agent/values.yaml
@@ -182,7 +182,7 @@ cansoAgent:
       pullPolicy: Always
       ## @param cansoAgent.deployment.image.tag Tag for the image
       ##
-      tag: "sha256:4d61db5d64cfa7e4c3cf8fbf8a4d2070b3a67926446e0bfa5de6f149af3baf00"
+      tag: "sha256:21a5f89c583b9a73c152110b87840ed408f799e1193efd0c4d1548e8582ff5f9"
     ## @section resources configuration
     resources:
       ## @section resources limits configuration
@@ -237,7 +237,7 @@ cansoAgent:
       pullPolicy: Always
       ## @param cansoAgent.proxyDeployment.image.tag Tag for the image
       ##
-      tag: "sha256:24bd248684c38b9f7b7edce4fac91f052c5e4435f088d1b169be30a93ff5e2b5"
+      tag: "sha256:bad8eb8fe5561d17773eeaef041ac7f0ec478d7b89115a3d76109804c24793bc"
     ## @section resources configuration
     resources:
       ## @section resources limits configuration

--- a/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.14
+version: 0.1.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.15
+version: 0.1.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
@@ -28,7 +28,7 @@ spec:
       source:
         repoURL: 'https://yugen-ai.github.io/canso-helm-charts'
         chart: canso-agent
-        targetRevision: 0.1.10
+        targetRevision: 0.1.11
         helm:
           values: |-
             config:


### PR DESCRIPTION
### Description

This PR updates the image version for dev agent deployments to the latest version. This is intended to deploy the issue fixed in https://github.com/Yugen-ai/platform-dev-agent/pull/33.

### Deployment

Follow instructions in [docs](https://docs.canso.ai/getting-started/canso-helm-charts#updating-the-chart)

### Rollback

Run `helm rollback`