### PR TITLE
Add single quotes to ai agent checkpoint db port number env variable

### DIFF
--- a/canso-data-plane/canso-ai-agent/Chart.yaml
+++ b/canso-data-plane/canso-ai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: canso-ai-agent
 description: A Helm chart for deploying AI agent services
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: "0.0.1"

--- a/canso-data-plane/canso-ai-agent/templates/deployments.yaml
+++ b/canso-data-plane/canso-ai-agent/templates/deployments.yaml
@@ -27,7 +27,7 @@ spec:
             - name: CHECKPOINT_DB_HOST
               value: {{ .Values.checkpoint_db_host }}
             - name: CHECKPOINT_DB_PORT
-              value: {{ .Values.checkpoint_db_port }}
+              value: '{{ .Values.checkpoint_db_port }}'
             - name: CHECKPOINT_DB_PASSWORD
               value: {{ .Values.checkpoint_db_password }}
 

--- a/canso-data-plane/canso-ai-agent/values.yaml
+++ b/canso-data-plane/canso-ai-agent/values.yaml
@@ -22,7 +22,7 @@ broker_url: "broker_url"
 checkpoint_db_host: "checkpoint_db_host"
 
 ## @param checkpoint_db_port checkpoint db port
-checkpoint_db_port: "checkpoint_db_port"
+checkpoint_db_port: 5432
 
 ## @param checkpoint_db_password checkpoint db password
 checkpoint_db_password: "checkpoint_db_password"


### PR DESCRIPTION
### Description

This PR adds single quotes to ai agent checkpoint db port number env variable. This is intended to avoid below error:
```
one or more objects failed to apply, reason: failed to create typed patch
object (ai-agents/agent1; apps/v1, Kind=Deployment):
.spec.template.spec.containers[name="agent1"].env[name="CHECKPOINT_DB_PORT"].value:
expected string, got &value.valueUnstructured{Value:5432}. Retrying
attempt #5 at 1:52PM
```

### Testing

Will be tested in staging env.