### PR TITLE
[NOJIRA] Updating values.yaml and redis service

### DIFF
--- a/canso-data-plane/rule-evaluation-service/Chart.yaml
+++ b/canso-data-plane/rule-evaluation-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.2
+version: 0.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/rule-evaluation-service/README.md
+++ b/canso-data-plane/rule-evaluation-service/README.md
@@ -20,11 +20,11 @@
 | ---------------------------------------- | ------------------------------------------------------------------------------------------------- | -------------------------------- |
 | `external_secret.enabled`                | Enable the creation of the secret                                                                 | `true`                           |
 | `external_secret.name`                   | The name of the secret that will be created                                                       | `canso-rule-evaluation-service`  |
-| `external_secret.cluster_secret_role`    | The name of the cluster secret role creted in the cluster                                         | `rule-evaluation-secret`         |
+| `external_secret.cluster_secret_role`    | The name of the cluster secret role creted in the cluster                                         | `secretstore-by-role`            |
 | `external_secret.target_secret_name`     | The name of the secret that will be created                                                       | `docker-secret-cred`             |
 | `external_secret.target_secret_type`     | The type of the secret that will be created                                                       | `kubernetes.io/dockerconfigjson` |
 | `external_secret.target_secret_name_key` | The key within the secret in the external secrets store that holds the Docker configuration JSON. | `.dockerconfigjson`              |
-| `external_secret.aws_secret_name`        | The path to the secret in AWS Secrets Manager that contains the Docker credentials                | `canso/dockerhub`                |
+| `external_secret.aws_secret_name`        | The path to the secret in AWS Secrets Manager that contains the Docker credentials                | `canso-dockerhub-credentials`    |
 | `external_secret.aws_secret_key`         | The key within the secret in AWS Secrets Manager that contains the Docker credentials.            | `dockerhub`                      |
 
 ### Deployment 
@@ -42,7 +42,8 @@
 | `deployment.image.repository` | The image repository                                           | `shaktimaanbot/rule-evaluation-service` |
 | `deployment.image.pullPolicy` | Image pull policy                                              | `IfNotPresent`                          |
 | `deployment.image.tag`        | Overrides the image tag whose default is the chart appVersion. | `""`                                    |
-| `deployment.enableEnv`        | Enable the environment variables                               | `false`                                 |
+| `deployment.enableEnv`        | Enable the environment variables                               | `true`                                  |
+| `deployment.env`              | The environment variables                                      | `{}`                                    |
 | `deployment.enableEnvSecrets` | Enable the environment variables from secrets                  | `false`                                 |
 
 ### autoscaling 
@@ -76,15 +77,15 @@
 | Name                     | Description                                                    | Value           |
 | ------------------------ | -------------------------------------------------------------- | --------------- |
 | `redis.image.repository` | The image repository                                           | `bitnami/redis` |
-| `redis.image.tag`        | Overrides the image tag whose default is the chart appVersion. | `7.2.4`         |
+| `redis.image.tag`        | Overrides the image tag whose default is the chart appVersion. | `7.4.1`         |
 | `redis.image.pullPolicy` | Image pull policy                                              | `IfNotPresent`  |
 
 ### redis.auth 
 
-| Name                  | Description            | Value  |
-| --------------------- | ---------------------- | ------ |
-| `redis.auth.enabled`  | Enable the redis auth  | `true` |
-| `redis.auth.password` | password of redis auth | `""`   |
+| Name                  | Description            | Value   |
+| --------------------- | ---------------------- | ------- |
+| `redis.auth.enabled`  | Enable the redis auth  | `false` |
+| `redis.auth.password` | password of redis auth | `""`    |
 
 ### Ingress
 

--- a/canso-data-plane/rule-evaluation-service/templates/redis.yaml
+++ b/canso-data-plane/rule-evaluation-service/templates/redis.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "canso-rule-evaluation-service.name" . }}
+  name: {{ include "canso-rule-evaluation-service.name" . }}-redis
   labels:
     app: {{ include "canso-rule-evaluation-service.name" . }}-redis
 spec:
@@ -24,14 +24,18 @@ spec:
               containerPort: 6379
               protocol: TCP
           env:
+            {{- if .Values.redis.auth.enabled }}
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.workflowName }}-redis
                   key: redis-password
+            {{- end }}
           resources:
             {{- toYaml .Values.redis.resources | nindent 12 }}
 ---
+
+{{- if .Values.redis.auth.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -41,15 +45,17 @@ metadata:
 type: Opaque
 data:
   redis-password: {{ .Values.redis.auth.password | b64enc }}
+{{- end }}
+
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "canso-rule-evaluation-service.name" . }}
+  name: {{ include "canso-rule-evaluation-service.name" . }}-redis
   labels:
     app: {{ include "canso-rule-evaluation-service.name" . }}-redis
 spec:
-  type: ClusterIP
+  type: NodePort
   ports:
     - port: 6379
       targetPort: redis

--- a/canso-data-plane/rule-evaluation-service/values.yaml
+++ b/canso-data-plane/rule-evaluation-service/values.yaml
@@ -28,7 +28,7 @@ external_secret:
   name: *service_name
   ## @param external_secret.cluster_secret_role The name of the cluster secret role creted in the cluster
   ##
-  cluster_secret_role: rule-evaluation-secret
+  cluster_secret_role: secretstore-by-role
   ## @param external_secret.target_secret_name The name of the secret that will be created
   ##
   target_secret_name: &image_pull_secret_name docker-secret-cred
@@ -40,7 +40,7 @@ external_secret:
   target_secret_name_key: .dockerconfigjson
   ## @param external_secret.aws_secret_name The path to the secret in AWS Secrets Manager that contains the Docker credentials
   ##
-  aws_secret_name: canso/dockerhub
+  aws_secret_name: canso-dockerhub-credentials
   ## @param external_secret.aws_secret_key The key within the secret in AWS Secrets Manager that contains the Docker credentials.
   ##
   aws_secret_key: dockerhub
@@ -82,7 +82,11 @@ deployment:
       cpu: "50m"
       memory: "100Mi"
   ## @param deployment.enableEnv Enable the environment variables
-  enableEnv: false
+  enableEnv: true
+
+  ## @param deployment.env The environment variables
+  env:  {}
+  
   ## @param deployment.enableEnvSecrets Enable the environment variables from secrets
   enableEnvSecrets: false
 
@@ -122,14 +126,14 @@ redis:
     ## @param redis.image.repository The image repository
     repository: bitnami/redis
     ## @param redis.image.tag Overrides the image tag whose default is the chart appVersion.
-    tag: "7.2.4"
+    tag: "7.4.1"
     ## @param redis.image.pullPolicy Image pull policy
     pullPolicy: IfNotPresent
   
   ## @section redis.auth 
   auth:
     ## @param redis.auth.enabled Enable the redis auth
-    enabled: true
+    enabled: false
     ## @param redis.auth.password password of redis auth
     password: ""
   


### PR DESCRIPTION
### Description

This PR
1. Adds a suffix `-redis` to the redis deployment and service in the rule evaluation service helm chart
2. Disable the auth by default
3. Updates a few values.yaml that needed to be updated in the management service
4. Bumps the chart version


### Testing

<details><summary>helm template . </summary>
<p>

```
---
# Source: canso-rule-evaluation-service/templates/redis.yaml
---
apiVersion: v1
kind: Service
metadata:
  name: canso-rule-evaluation-service-redis
  labels:
    app: canso-rule-evaluation-service-redis
spec:
  type: NodePort
  ports:
    - port: 6379
      targetPort: redis
      protocol: TCP
      name: redis
  selector:
    app: canso-rule-evaluation-service-redis
---
# Source: canso-rule-evaluation-service/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: canso-rule-evaluation-service
  namespace: rule-evaluation
spec:
  type: NodePort
  selector:
    app: canso-rule-evaluation-service
  ports:
  - name: http
    port: 80
    protocol: TCP
    targetPort: 8000
  - name: https
    port: 443
    protocol: TCP
    targetPort: 8000
---
# Source: canso-rule-evaluation-service/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: canso-rule-evaluation-service
  name: canso-rule-evaluation-service
  namespace: rule-evaluation
spec:
  replicas: 1
  selector:
    matchLabels:
      app: canso-rule-evaluation-service
  template:
    metadata:
      annotations:
        'consul.hashicorp.com/connect-inject': 'false'
      labels:
        app: canso-rule-evaluation-service
    spec:
      containers:
      - name: canso-rule-evaluation-service
        image: shaktimaanbot/rule-evaluation-service:v0.0.1-python-3.12-slim
        ports:
        - containerPort: 8000
        resources:
          limits:
            cpu: 400m
            memory: 500Mi
          requests:
            cpu: 50m
            memory: 100Mi
        env:
      imagePullSecrets:
        - name: docker-secret-cred
---
# Source: canso-rule-evaluation-service/templates/redis.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: canso-rule-evaluation-service-redis
  labels:
    app: canso-rule-evaluation-service-redis
spec:
  replicas: 1
  selector:
    matchLabels:
      app: canso-rule-evaluation-service-redis
  template:
    metadata:
      labels:
        app: canso-rule-evaluation-service-redis
    spec:
      containers:
        - name: redis
          image: "bitnami/redis:7.4.1"
          imagePullPolicy: IfNotPresent
          ports:
            - name: redis
              containerPort: 6379
              protocol: TCP
          env:
          resources:
            limits:
              cpu: 200m
              memory: 256Mi
            requests:
              cpu: 100m
              memory: 128Mi
---
# Source: canso-rule-evaluation-service/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: canso-rule-evaluation-service-ing
  namespace: rule-evaluation
  labels:
    app: canso-rule-evaluation-service
  annotations:
    nginx.org/mergeable-ingress-type: minion
spec:
  ingressClassName: nginx
  rules:
    - host: "*.com"
      http:
        paths:
          - backend:
              service:
                name: canso-rule-evaluation-service
                port:
                  number: 80
            path: /v1/risk
            pathType: Prefix
---
# Source: canso-rule-evaluation-service/templates/external-secret.yaml
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: canso-rule-evaluation-service-es
  namespace: rule-evaluation
spec:
  refreshInterval: 1m
  secretStoreRef:
    name: secretstore-by-role
    kind: ClusterSecretStore
  target:
    name: docker-secret-cred 
    template:
      type: kubernetes.io/dockerconfigjson 
  data:
  - secretKey: .dockerconfigjson 
    remoteRef:
      key: canso-dockerhub-credentials 
      property: dockerhub

```

</p>
</details> 

### Deployment

1. Merge the PR
2. Check the github action for the release version 

### Rollback

1. Revert the PR
2. Delete the version form the index.yaml
