### PR TITLE
[NOJIRA] Fixing redis secret ref and namespace

### DIFF
--- a/canso-data-plane/rule-evaluation-service/Chart.yaml
+++ b/canso-data-plane/rule-evaluation-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.4
+version: 0.0.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/rule-evaluation-service/templates/redis.yaml
+++ b/canso-data-plane/rule-evaluation-service/templates/redis.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "canso-rule-evaluation-service.name" . }}-redis
+  namespace: {{ .Values.namespaceOverride }}
   labels:
     app: {{ include "canso-rule-evaluation-service.name" . }}-redis
 spec:
@@ -28,7 +29,7 @@ spec:
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ .Values.workflowName }}-redis
+                  name: {{ include "canso-rule-evaluation-service.name" . }}-redis
                   key: redis-password
             {{- end }}
           resources:
@@ -39,7 +40,8 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "canso-rule-evaluation-service.name" . }}
+  name: {{ include "canso-rule-evaluation-service.name" . }}-redis
+  namespace: {{ .Values.namespaceOverride }}
   labels:
     app: {{ include "canso-rule-evaluation-service.name" . }}-redis
 type: Opaque
@@ -52,6 +54,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "canso-rule-evaluation-service.name" . }}-redis
+  namespace: {{ .Values.namespaceOverride }}
   labels:
     app: {{ include "canso-rule-evaluation-service.name" . }}-redis
 spec:


### PR DESCRIPTION
### Description

This Pr adds the following to the risk evaluation service
1. namespaceOverride to the redis deployment
2. Updates secret key ref for the redis deployment


### testing

To be tested in the dataplane repo

helm template

```
# Source: canso-rule-evaluation-service/templates/redis.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: canso-rule-evaluation-service-redis
  namespace: rule-evaluation
  labels:
    app: canso-rule-evaluation-service-redis
spec:
  replicas: 1
  selector:
    matchLabels:
      app: canso-rule-evaluation-service-redis
  template:
    metadata:
      labels:
        app: canso-rule-evaluation-service-redis
    spec:
      containers:
        - name: redis
          image: "bitnami/redis:7.4.1"
          imagePullPolicy: IfNotPresent
          ports:
            - name: redis
              containerPort: 6379
              protocol: TCP
          env:
            - name: REDIS_PASSWORD
              valueFrom:
                secretKeyRef:
                  name: canso-rule-evaluation-service-redis
                  key: redis-password
          resources:
            limits:
              cpu: 200m
              memory: 256Mi
            requests:
              cpu: 100m
              memory: 128Mi
```