### PR TITLE
[NOJIRA] Remove auth and change redis image

### DIFF
--- a/canso-data-plane/rule-evaluation-service/Chart.yaml
+++ b/canso-data-plane/rule-evaluation-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.5
+version: 0.0.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/rule-evaluation-service/README.md
+++ b/canso-data-plane/rule-evaluation-service/README.md
@@ -74,18 +74,18 @@
 
 ### redis.image 
 
-| Name                     | Description                                                    | Value           |
-| ------------------------ | -------------------------------------------------------------- | --------------- |
-| `redis.image.repository` | The image repository                                           | `bitnami/redis` |
-| `redis.image.tag`        | Overrides the image tag whose default is the chart appVersion. | `7.4.1`         |
-| `redis.image.pullPolicy` | Image pull policy                                              | `IfNotPresent`  |
+| Name                     | Description                                                    | Value          |
+| ------------------------ | -------------------------------------------------------------- | -------------- |
+| `redis.image.repository` | The image repository                                           | `redis`        |
+| `redis.image.tag`        | Overrides the image tag whose default is the chart appVersion. | `7.4.2`        |
+| `redis.image.pullPolicy` | Image pull policy                                              | `IfNotPresent` |
 
 ### redis.auth 
 
-| Name                  | Description            | Value      |
-| --------------------- | ---------------------- | ---------- |
-| `redis.auth.enabled`  | Enable the redis auth  | `true`     |
-| `redis.auth.password` | password of redis auth | `WKdJ0Y2k` |
+| Name                  | Description            | Value   |
+| --------------------- | ---------------------- | ------- |
+| `redis.auth.enabled`  | Enable the redis auth  | `false` |
+| `redis.auth.password` | password of redis auth | `""`    |
 
 ### Ingress
 

--- a/canso-data-plane/rule-evaluation-service/values.yaml
+++ b/canso-data-plane/rule-evaluation-service/values.yaml
@@ -124,18 +124,18 @@ redis:
   ## @section redis.image 
   image:
     ## @param redis.image.repository The image repository
-    repository: bitnami/redis
+    repository: redis
     ## @param redis.image.tag Overrides the image tag whose default is the chart appVersion.
-    tag: "7.4.1"
+    tag: "7.4.2"
     ## @param redis.image.pullPolicy Image pull policy
     pullPolicy: IfNotPresent
   
   ## @section redis.auth 
   auth:
     ## @param redis.auth.enabled Enable the redis auth
-    enabled: true
+    enabled: false
     ## @param redis.auth.password password of redis auth
-    password: "WKdJ0Y2k"  # random password genrated by openssl
+    password: ""
   
   ## @skip redis.resources The resources requests and limits for the container.
   resources:


### PR DESCRIPTION
### Description

1. We are removing the auth here due to secret issues in the dev agent.
2. The bitnami/redis image requires the auth for deployment. So we are now using the official redis image instead


### testing

Applied the deployment template in the dataplane cluster

```
# Source: canso-rule-evaluation-service/templates/redis.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: canso-rule-evaluation-service-redis
  namespace: default
  labels:
    app: canso-rule-evaluation-service-redis
spec:
  replicas: 1
  selector:
    matchLabels:
      app: canso-rule-evaluation-service-redis
  template:
    metadata:
      labels:
        app: canso-rule-evaluation-service-redis
    spec:
      containers:
        - name: redis
          image: "redis:7.4.2"
          imagePullPolicy: IfNotPresent
          ports:
            - name: redis
              containerPort: 6379
              protocol: TCP
          env:
          resources:
            limits:
              cpu: 200m
              memory: 256Mi
            requests:
              cpu: 100m
              memory: 128Mi
```