### PR TITLE
[NOJIRA]Bump chart version to 0.0.8 and update RIsk ingress

### DIFF
--- a/canso-data-plane/canso-rule-evaluation-service/Chart.yaml
+++ b/canso-data-plane/canso-rule-evaluation-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.7
+version: 0.0.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-rule-evaluation-service/README.md
+++ b/canso-data-plane/canso-rule-evaluation-service/README.md
@@ -74,17 +74,17 @@
 
 ### redis.initJob
 
-| Name                        | Description                   | Value  |
-| --------------------------- | ----------------------------- | ------ |
-| `redis.initJob.enabled`     | Enable the initialization job | `true` |
-| `redis.initJob.workflowKey` | The workflow key              | `""`   |
-| `redis.initJob.ruleEntries` | The rule entries              | `{}`   |
+| Name                        | Description                   | Value   |
+| --------------------------- | ----------------------------- | ------- |
+| `redis.initJob.enabled`     | Enable the initialization job | `false` |
+| `redis.initJob.workflowKey` | The workflow key              | `""`    |
+| `redis.initJob.ruleEntries` | The rule entries              | `{}`    |
 
 ### redis.persistence
 
 | Name                             | Description                                          | Value               |
 | -------------------------------- | ---------------------------------------------------- | ------------------- |
-| `redis.persistence.enabled`      | Enable persistence for redis instance                | `true`              |
+| `redis.persistence.enabled`      | Enable persistence for redis instance                | `false`             |
 | `redis.persistence.storageClass` | Specify the storage class or leave blank for default | `""`                |
 | `redis.persistence.size`         | Size of the PersistentVolumeClaim                    | `1Gi`               |
 | `redis.persistence.accessModes`  | Define access modes                                  | `["ReadWriteOnce"]` |

--- a/canso-data-plane/canso-rule-evaluation-service/templates/config-map-init.yaml
+++ b/canso-data-plane/canso-rule-evaluation-service/templates/config-map-init.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.redis.initJob.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -36,3 +37,4 @@ data:
 
     # Initialize rule entries
     client.mset(rule_entries)
+{{- end }}

--- a/canso-data-plane/canso-rule-evaluation-service/templates/ingress.yaml
+++ b/canso-data-plane/canso-rule-evaluation-service/templates/ingress.yaml
@@ -8,6 +8,7 @@ metadata:
     app: {{ include "canso-rule-evaluation-service.name" . }}
   annotations:
     {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    nginx.org/rewrites: serviceName={{ include "canso-rule-evaluation-service.name" . }} rewrite={{ .Values.ingress.path }}
 spec:
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   rules:
@@ -19,6 +20,6 @@ spec:
                 name: {{ include "canso-rule-evaluation-service.name" . }}
                 port:
                   number: 80
-            path: {{ .Values.ingress.path }}
+            path: /{{ include "canso-rule-evaluation-service.name" . }}{{ .Values.ingress.path }}
             pathType: {{ .Values.ingress.pathType }}
 {{- end }}

--- a/canso-data-plane/canso-rule-evaluation-service/values.yaml
+++ b/canso-data-plane/canso-rule-evaluation-service/values.yaml
@@ -125,7 +125,7 @@ redis:
   ## @section redis.initJob
   initJob:
     ## @param redis.initJob.enabled Enable the initialization job
-    enabled: true  
+    enabled: false  
     ## @param redis.initJob.workflowKey The workflow key
     workflowKey: ""
     ## @param redis.initJob.ruleEntries The rule entries
@@ -134,7 +134,7 @@ redis:
   ## @section redis.persistence
   persistence:
     ## @param redis.persistence.enabled Enable persistence for redis instance
-    enabled: true 
+    enabled: false 
     ## @param redis.persistence.storageClass Specify the storage class or leave blank for default
     storageClass: ""  
     ## @param redis.persistence.size Size of the PersistentVolumeClaim


### PR DESCRIPTION
### Desciption

This PR fixes the ingress path conflict issues. Since multiple paths were deployed at  `v1/risk` the endpoint was thwoing an error.

Now the endpoint has the nameOverride added in the path `{{ include "canso-rule-evaluation-service.name" . }}{{ .Values.ingress.path }}`

Changes
- Modified ingress.yaml to adjust the path for the service name.
- Incremented the chart version in Chart.yaml to 0.0.8.
- Disabled the Redis initialization job and persistence in values.yaml.
- Updated config-map-init.yaml to conditionally include initialization logic based on the new Redis settings.


### Testing

Tested in the dataplane cluster

```
helm install risk-test-ing /Users/mishrasandeep/Documents/canso-helm-charts/canso-helm-charts/canso-data-plane/canso-rule-evaluation-service --set namespaceOverride=risk-test-ing -n risk-test-ing --create-namespace
```

<img width="1309" alt="Screenshot 2025-01-14 at 6 02 08 PM" src="https://github.com/user-attachments/assets/aeacfedf-2f92-4340-b90c-9b51a187cd7f" />
<img width="1201" alt="Screenshot 2025-01-14 at 6 04 52 PM" src="https://github.com/user-attachments/assets/7bb44459-5494-4225-bd0e-976c0c520abc" />

