### PR TITLE
[NOJIRA] Update Chart version and add annotations

### DIFF
--- a/canso-data-plane/canso-rule-evaluation-service/Chart.yaml
+++ b/canso-data-plane/canso-rule-evaluation-service/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.8
+version: 0.0.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.0.1-python-3.12-slim"
+appVersion: "v0.0.2-python-3.12-slim"

--- a/canso-data-plane/canso-rule-evaluation-service/templates/service.yaml
+++ b/canso-data-plane/canso-rule-evaluation-service/templates/service.yaml
@@ -3,6 +3,11 @@ kind: Service
 metadata:
   name: {{ include "canso-rule-evaluation-service.name" . }}
   namespace: {{ .Values.namespaceOverride }}
+  annotations:
+    prometheus.io/scrape: "true"
+    prometheus.io/port: "{{ .Values.service.targetport }}"
+    prometheus.io/path: "/metrics"
+    prometheus.io/scheme: "http"
 spec:
   type: NodePort
   selector:


### PR DESCRIPTION

### Description
Added Prometheus discovery annotations in a serverYAML file and bumped chart version.


### Testing 
Tested using helm template cmd.

<details><summary> Template Response </summary>
<p>

```
---
# Source: canso-rule-evaluation-service/templates/redis.yaml
---
apiVersion: v1
kind: Service
metadata:
  name: canso-rule-evaluation-service-redis
  namespace: rule-evaluation
  labels:
    app: canso-rule-evaluation-service-redis
spec:
  type: NodePort
  ports:
    - port: 6379
      targetPort: redis
      protocol: TCP
      name: redis
  selector:
    app: canso-rule-evaluation-service-redis
---
# Source: canso-rule-evaluation-service/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: canso-rule-evaluation-service
  namespace: rule-evaluation
  annotations:
    prometheus.io/scrape: "true"
    prometheus.io/port: "8000"
    prometheus.io/path: "/metrics"
    prometheus.io/scheme: "http"
spec:
  type: NodePort
  selector:
    app: canso-rule-evaluation-service
  ports:
  - name: http
    port: 80
    protocol: TCP
    targetPort: 8000
  - name: https
    port: 443
    protocol: TCP
    targetPort: 8000
---
# Source: canso-rule-evaluation-service/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: canso-rule-evaluation-service
  name: canso-rule-evaluation-service
  namespace: rule-evaluation
spec:
  replicas: 1
  selector:
    matchLabels:
      app: canso-rule-evaluation-service
  template:
    metadata:
      annotations:
        'consul.hashicorp.com/connect-inject': 'false'
      labels:
        app: canso-rule-evaluation-service
    spec:
      containers:
      - name: canso-rule-evaluation-service
        image: shaktimaanbot/rule-evaluation-service:v0.0.2-python-3.12-slim
        ports:
        - containerPort: 8000
        resources:
          limits:
            cpu: 400m
            memory: 500Mi
          requests:
            cpu: 50m
            memory: 100Mi
        env:
      imagePullSecrets:
        - name: docker-secret-cred
---
# Source: canso-rule-evaluation-service/templates/redis.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: canso-rule-evaluation-service-redis
  namespace: rule-evaluation
  labels:
    app: canso-rule-evaluation-service-redis
spec:
  replicas: 1
  selector:
    matchLabels:
      app: canso-rule-evaluation-service-redis
  template:
    metadata:
      labels:
        app: canso-rule-evaluation-service-redis
    spec:
      containers:
        - name: redis
          image: "redis:7.4.2"
          imagePullPolicy: IfNotPresent
          ports:
            - name: redis
              containerPort: 6379
              protocol: TCP
          env:
          resources:
            limits:
              cpu: 200m
              memory: 256Mi
            requests:
              cpu: 100m
              memory: 128Mi
---
# Source: canso-rule-evaluation-service/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: canso-rule-evaluation-service-ing
  namespace: rule-evaluation
  labels:
    app: canso-rule-evaluation-service
  annotations:
    nginx.org/mergeable-ingress-type: minion
    nginx.org/rewrites: serviceName=canso-rule-evaluation-service rewrite=/v1/risk
spec:
  ingressClassName: nginx
  rules:
    - host: "*.com"
      http:
        paths:
          - backend:
              service:
                name: canso-rule-evaluation-service
                port:
                  number: 80
            path: /canso-rule-evaluation-service/v1/risk
            pathType: Prefix
---
# Source: canso-rule-evaluation-service/templates/external-secret.yaml
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: canso-rule-evaluation-service-es
  namespace: rule-evaluation
spec:
  refreshInterval: 1m
  secretStoreRef:
    name: secretstore-by-role
    kind: ClusterSecretStore
  target:
    name: docker-secret-cred 
    template:
      type: kubernetes.io/dockerconfigjson 
  data:
  - secretKey: .dockerconfigjson 
    remoteRef:
      key: canso-dockerhub-credentials 
      property: dockerhub

```

</p>
</details>

### Deployment
1. Standard PR merge.

### Rollback
1. Stnadrd PR revert.
2. Delete helm chart from gh-pages.