### PR TITLE
[NOJIRA] Add Argocd hooks for risk init job

### DIFF
--- a/canso-data-plane/canso-rule-evaluation-service/README.md
+++ b/canso-data-plane/canso-rule-evaluation-service/README.md
@@ -74,11 +74,11 @@
 
 ### redis.initJob
 
-| Name                        | Description                   | Value   |
-| --------------------------- | ----------------------------- | ------- |
-| `redis.initJob.enabled`     | Enable the initialization job | `false` |
-| `redis.initJob.workflowKey` | The workflow key              | `""`    |
-| `redis.initJob.ruleEntries` | The rule entries              | `{}`    |
+| Name                        | Description                   | Value  |
+| --------------------------- | ----------------------------- | ------ |
+| `redis.initJob.enabled`     | Enable the initialization job | `true` |
+| `redis.initJob.workflowKey` | The workflow key              | `""`   |
+| `redis.initJob.ruleEntries` | The rule entries              | `{}`   |
 
 ### redis.persistence
 

--- a/canso-data-plane/canso-rule-evaluation-service/templates/redis-init-job.yaml
+++ b/canso-data-plane/canso-rule-evaluation-service/templates/redis-init-job.yaml
@@ -7,6 +7,9 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
+    "argocd.argoproj.io/hook": Sync
+    "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation, HookSucceeded
+    "argocd.argoproj.io/sync-wave": "1"
 spec:
   template:
     spec:

--- a/canso-data-plane/canso-rule-evaluation-service/values.yaml
+++ b/canso-data-plane/canso-rule-evaluation-service/values.yaml
@@ -125,7 +125,7 @@ redis:
   ## @section redis.initJob
   initJob:
     ## @param redis.initJob.enabled Enable the initialization job
-    enabled: false  
+    enabled: true  
     ## @param redis.initJob.workflowKey The workflow key
     workflowKey: ""
     ## @param redis.initJob.ruleEntries The rule entries


### PR DESCRIPTION

### Description

Adding argocd hooks to the redis-init-job

### Testing

helm template

```
# Source: canso-rule-evaluation-service/templates/redis-init-job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: canso-rule-evaluation-service-redis-init
  namespace: rule-evaluation
  annotations:
    "helm.sh/hook": post-install,post-upgrade
    "helm.sh/hook-delete-policy": before-hook-creation
    "argocd.argoproj.io/hook": Sync
    "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation, HookSucceeded
    "argocd.argoproj.io/sync-wave": "1"
spec:
  template:
    spec:
      restartPolicy: Never
      containers:
        - name: redis-init
          image: python:3.12-slim
          command: ["sh", "-c"]
          args:
            - |
              pip install redis &&
              python /scripts/redis-init.py
          volumeMounts:
            - name: redis-init-script
              mountPath: /scripts
      volumes:
        - name: redis-init-script
          configMap:
            name: canso-rule-evaluation-service-redis-init-script
      env:

```