### PR TITLE
Update the canso dev agent image tag

### DIFF
--- a/canso-data-plane/canso-agent/Chart.yaml
+++ b/canso-data-plane/canso-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.14
+version: 0.1.15
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-agent/README.md
+++ b/canso-data-plane/canso-agent/README.md
@@ -88,7 +88,7 @@
 | ---------------------------------------- | ------------------------- | ------------------------------------------------------------------------- |
 | `cansoAgent.deployment.image.repository` | repository for the image  | `shaktimaanbot/dev-agent-image`                                           |
 | `cansoAgent.deployment.image.pullPolicy` | Pull policy for the image | `Always`                                                                  |
-| `cansoAgent.deployment.image.tag`        | Tag for the image         | `sha256:155f88cb7259970bc4043c6d776d52ea6d645cd63be98f04e61a8c9621070ac8` |
+| `cansoAgent.deployment.image.tag`        | Tag for the image         | `sha256:01582ca3bc43f2d3f3070beb8942b2ba0725d61948e0b4541241be3ff4cad091` |
 
 ### resources configuration
 
@@ -120,7 +120,7 @@
 | --------------------------------------------- | ------------------------- | ------------------------------------------------------------------------- |
 | `cansoAgent.proxyDeployment.image.repository` | repository for the image  | `shaktimaanbot/dev-agent-image`                                           |
 | `cansoAgent.proxyDeployment.image.pullPolicy` | Pull policy for the image | `Always`                                                                  |
-| `cansoAgent.proxyDeployment.image.tag`        | Tag for the image         | `sha256:3f133f247a96de599edacba389c167610f6efbefef898321856ec53e9a1278de` |
+| `cansoAgent.proxyDeployment.image.tag`        | Tag for the image         | `sha256:01582ca3bc43f2d3f3070beb8942b2ba0725d61948e0b4541241be3ff4cad091` |
 
 ### resources configuration
 

--- a/canso-data-plane/canso-agent/values.yaml
+++ b/canso-data-plane/canso-agent/values.yaml
@@ -182,7 +182,7 @@ cansoAgent:
       pullPolicy: Always
       ## @param cansoAgent.deployment.image.tag Tag for the image
       ##
-      tag: "sha256:155f88cb7259970bc4043c6d776d52ea6d645cd63be98f04e61a8c9621070ac8"
+      tag: "sha256:01582ca3bc43f2d3f3070beb8942b2ba0725d61948e0b4541241be3ff4cad091"
     ## @section resources configuration
     resources:
       ## @section resources limits configuration
@@ -239,7 +239,7 @@ cansoAgent:
       ##
       # Do not rely on the chart's `appVersion` since the proxy and the core agent
       # are on different positions in the semver progression.
-      tag: "sha256:3f133f247a96de599edacba389c167610f6efbefef898321856ec53e9a1278de"
+      tag: "sha256:01582ca3bc43f2d3f3070beb8942b2ba0725d61948e0b4541241be3ff4cad091"
       
 
     ## @section resources configuration

--- a/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.19
+version: 0.1.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
@@ -28,7 +28,7 @@ spec:
       source:
         repoURL: 'https://yugen-ai.github.io/canso-helm-charts'
         chart: canso-agent
-        targetRevision: 0.1.14
+        targetRevision: 0.1.15
         helm:
           values: |-
             config:


### PR DESCRIPTION
This PR updates the docker image tag of the canso dev agent application.
This is intended to deploy the changes in https://github.com/Yugen-ai/platform-dev-agent/pull/38