### PR TITLE
[NOJIRA] Add Horizontal Pod Autoscaling (HPA) to Rule Evaluation Service

### DIFF
--- a/canso-data-plane/canso-rule-evaluation-service/Chart.yaml
+++ b/canso-data-plane/canso-rule-evaluation-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.10
+version: 0.0.11
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-rule-evaluation-service/README.md
+++ b/canso-data-plane/canso-rule-evaluation-service/README.md
@@ -33,7 +33,6 @@
 | ----------------------------------------------------- | -------------------------------------------------- | -------------------- |
 | `deployment.ImagePullSecrets.enabled`                 | Enable the creation of the secret                  | `true`               |
 | `deployment.ImagePullSecrets.private_registry_secret` | The name of the secret created by external secrets | `docker-secret-cred` |
-| `deployment.replicaCount`                             | Number of replicas to deploy                       | `1`                  |
 
 ### deployment.image 
 
@@ -48,9 +47,13 @@
 
 ### autoscaling 
 
-| Name                  | Description                     | Value   |
-| --------------------- | ------------------------------- | ------- |
-| `autoscaling.enabled` | enable autoscaling for the pods | `false` |
+| Name                                            | Description                          | Value  |
+| ----------------------------------------------- | ------------------------------------ | ------ |
+| `autoscaling.enabled`                           | enable autoscaling for the pods      | `true` |
+| `autoscaling.minReplicas`                       | minimum number of replicas           | `1`    |
+| `autoscaling.maxReplicas`                       | maximum number of replicas           | `10`   |
+| `autoscaling.targetCPUUtilizationPercentage`    | target CPU utilization percentage    | `80`   |
+| `autoscaling.targetMemoryUtilizationPercentage` | target memory utilization percentage | `80`   |
 
 ### taint 
 

--- a/canso-data-plane/canso-rule-evaluation-service/templates/deployment.yaml
+++ b/canso-data-plane/canso-rule-evaluation-service/templates/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Values.namespaceOverride }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
-  replicas: {{ .Values.deployment.replicaCount }}
+  replicas: 1
   {{- end }}
   selector:
     matchLabels:

--- a/canso-data-plane/canso-rule-evaluation-service/templates/hpa.yaml
+++ b/canso-data-plane/canso-rule-evaluation-service/templates/hpa.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "canso-rule-evaluation-service.name" . }}
+  namespace: {{ .Values.namespaceOverride }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "canso-rule-evaluation-service.name" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+{{- end }}

--- a/canso-data-plane/canso-rule-evaluation-service/values.yaml
+++ b/canso-data-plane/canso-rule-evaluation-service/values.yaml
@@ -61,8 +61,6 @@ deployment:
     ##
     private_registry_secret: *image_pull_secret_name
 
-  ## @param deployment.replicaCount Number of replicas to deploy
-  replicaCount: 1
 
   ## @section deployment.image 
   image:
@@ -93,7 +91,15 @@ deployment:
 ## @section autoscaling 
 autoscaling:
   ## @param autoscaling.enabled enable autoscaling for the pods
-  enabled: false
+  enabled: true
+  ## @param autoscaling.minReplicas minimum number of replicas
+  minReplicas: 1
+  ## @param autoscaling.maxReplicas maximum number of replicas
+  maxReplicas: 10
+  ## @param autoscaling.targetCPUUtilizationPercentage target CPU utilization percentage
+  targetCPUUtilizationPercentage: 80
+  ## @param autoscaling.targetMemoryUtilizationPercentage target memory utilization percentage
+  targetMemoryUtilizationPercentage: 80
 
 ## @section taint 
 taint:


### PR DESCRIPTION
### Descriptions

This PR adds HPA to the Rule Evaluation Service, allowing it to automatically adjust the number of pods based on CPU and memory usage. This improvement boosts resource efficiency and enhances service reliability during fluctuating workloads.

### Testing
I have tested using helm template cmd.

<details><summary> Helm Template Result </summary>
<p>

```
---
# Source: canso-rule-evaluation-service/templates/config-map-init.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: canso-rule-evaluation-service-redis-init-script
  namespace: rule-evaluation
data:
  redis-init.py: |
    import redis
    import json
    import time

    # Function to connect to Redis with retries
    def connect_to_redis_with_retries(host, port, retries=6, delay=10):
        for attempt in range(1, retries + 1):
            try:
                client = redis.Redis(host=host, port=port, socket_connect_timeout=5)
                client.ping()  
                return client
            except redis.ConnectionError as e:
                if attempt < retries:
                    time.sleep(delay)
        raise Exception('Failed to connect to Redis after multiple retries.')

    # Connect to Redis
    redis_host = "canso-rule-evaluation-service-redis"
    redis_port = 6379
    client = connect_to_redis_with_retries(host=redis_host, port=redis_port)

    # Extract rule IDs from rule entries
    rule_entries = {}
    rule_ids = [key.split('::')[1] for key in rule_entries.keys()]

    # Initialize the workflow key
    workflow_key = ""
    client.sadd(workflow_key, *rule_ids)

    # Initialize rule entries
    client.mset(rule_entries)
---
# Source: canso-rule-evaluation-service/templates/redis.yaml
---
apiVersion: v1
kind: Service
metadata:
  name: canso-rule-evaluation-service-redis
  namespace: rule-evaluation
  labels:
    app: canso-rule-evaluation-service-redis
spec:
  type: NodePort
  ports:
    - port: 6379
      targetPort: redis
      protocol: TCP
      name: redis
  selector:
    app: canso-rule-evaluation-service-redis
---
# Source: canso-rule-evaluation-service/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: canso-rule-evaluation-service
  namespace: rule-evaluation
  annotations:
    prometheus.io/scrape: "true"
    prometheus.io/port: "8000"
    prometheus.io/path: "/metrics"
    prometheus.io/scheme: "http"
spec:
  type: NodePort
  selector:
    app: canso-rule-evaluation-service
  ports:
  - name: http
    port: 80
    protocol: TCP
    targetPort: 8000
  - name: https
    port: 443
    protocol: TCP
    targetPort: 8000
---
# Source: canso-rule-evaluation-service/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: canso-rule-evaluation-service
  name: canso-rule-evaluation-service
  namespace: rule-evaluation
spec:
  selector:
    matchLabels:
      app: canso-rule-evaluation-service
  template:
    metadata:
      annotations:
        'consul.hashicorp.com/connect-inject': 'false'
      labels:
        app: canso-rule-evaluation-service
    spec:
      containers:
      - name: canso-rule-evaluation-service
        image: shaktimaanbot/rule-evaluation-service:v0.0.2-python-3.12-slim
        ports:
        - containerPort: 8000
        resources:
          limits:
            cpu: 400m
            memory: 500Mi
          requests:
            cpu: 50m
            memory: 100Mi
        env:
      imagePullSecrets:
        - name: docker-secret-cred
---
# Source: canso-rule-evaluation-service/templates/redis.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: canso-rule-evaluation-service-redis
  namespace: rule-evaluation
  labels:
    app: canso-rule-evaluation-service-redis
spec:
  replicas: 1
  selector:
    matchLabels:
      app: canso-rule-evaluation-service-redis
  template:
    metadata:
      labels:
        app: canso-rule-evaluation-service-redis
    spec:
      containers:
        - name: redis
          image: "redis:7.4.2"
          imagePullPolicy: IfNotPresent
          ports:
            - name: redis
              containerPort: 6379
              protocol: TCP
          env:
          resources:
            limits:
              cpu: 200m
              memory: 256Mi
            requests:
              cpu: 100m
              memory: 128Mi
---
# Source: canso-rule-evaluation-service/templates/hpa.yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: canso-rule-evaluation-service
  namespace: rule-evaluation
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: canso-rule-evaluation-service
  minReplicas: 1
  maxReplicas: 10
  metrics:
    - type: Resource
      resource:
        name: cpu
        target:
          type: Utilization
          averageUtilization: 80
    - type: Resource
      resource:
        name: memory
        target:
          type: Utilization
          averageUtilization: 80
---
# Source: canso-rule-evaluation-service/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: canso-rule-evaluation-service-ing
  namespace: rule-evaluation
  labels:
    app: canso-rule-evaluation-service
  annotations:
    nginx.org/mergeable-ingress-type: minion
    nginx.org/rewrites: serviceName=canso-rule-evaluation-service rewrite=/v1/risk
spec:
  ingressClassName: nginx
  rules:
    - host: "*.com"
      http:
        paths:
          - backend:
              service:
                name: canso-rule-evaluation-service
                port:
                  number: 80
            path: /canso-rule-evaluation-service/v1/risk
            pathType: Prefix
---
# Source: canso-rule-evaluation-service/templates/external-secret.yaml
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: canso-rule-evaluation-service-es
  namespace: rule-evaluation
spec:
  refreshInterval: 1m
  secretStoreRef:
    name: secretstore-by-role
    kind: ClusterSecretStore
  target:
    name: docker-secret-cred 
    template:
      type: kubernetes.io/dockerconfigjson 
  data:
  - secretKey: .dockerconfigjson 
    remoteRef:
      key: canso-dockerhub-credentials 
      property: dockerhub
---
# Source: canso-rule-evaluation-service/templates/redis-init-job.yaml
apiVersion: batch/v1
kind: Job
metadata:
  name: canso-rule-evaluation-service-redis-init
  namespace: rule-evaluation
  annotations:
    "helm.sh/hook": post-install,post-upgrade
    "helm.sh/hook-delete-policy": before-hook-creation
    "argocd.argoproj.io/hook": Sync
    "argocd.argoproj.io/hook-delete-policy": BeforeHookCreation, HookSucceeded
    "argocd.argoproj.io/sync-wave": "1"
spec:
  template:
    spec:
      restartPolicy: Never
      containers:
        - name: redis-init
          image: python:3.12-slim
          command: ["sh", "-c"]
          args:
            - |
              pip install redis &&
              python /scripts/redis-init.py
          volumeMounts:
            - name: redis-init-script
              mountPath: /scripts
          env:
      volumes:
        - name: redis-init-script
          configMap:
            name: canso-rule-evaluation-service-redis-init-script

```

</p>
</details>

### Deployment
1. Standard PR merge.
2. Update chart version in workflows mgmt service.

### Rollback
1. Stndard PR revert.
2. Delete latest Release on gh-pages.
