### PR TITLE
Add service account and optional aws roleArn

### DIFF
--- a/canso-data-plane/canso-ai-agent/Chart.yaml
+++ b/canso-data-plane/canso-ai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: canso-ai-agent
 description: A Helm chart for deploying AI agent services
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "0.0.1"

--- a/canso-data-plane/canso-ai-agent/README.md
+++ b/canso-data-plane/canso-ai-agent/README.md
@@ -46,3 +46,11 @@ This Helm chart deploys an AI agent service to Kubernetes. It is currently in an
 | `readinessProbe.timeoutSeconds`      | Timeout seconds for readinessProbe       | `5`     |
 | `readinessProbe.failureThreshold`    | Failure threshold for readinessProbe     | `3`     |
 | `readinessProbe.successThreshold`    | Success threshold for readinessProbe     | `1`     |
+
+### Service Account parameters
+
+| Name                         | Description                                              | Value   |
+| ---------------------------- | -------------------------------------------------------- | ------- |
+| `serviceAccount.annotations` | Additional custom annotations for the ServiceAccount     | `{}`    |
+| `serviceAccount.aws.enabled` | Enable AWS IAM role                                      | `false` |
+| `serviceAccount.aws.roleArn` | ARN of the IAM role to associate with the ServiceAccount | `""`    |

--- a/canso-data-plane/canso-ai-agent/templates/deployments.yaml
+++ b/canso-data-plane/canso-ai-agent/templates/deployments.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         {{- include "ai-agent.selectorLabels" . | nindent 8 }}
     spec:
+      serviceAccountName: {{ .Values.agent_name }}-sa
       containers:
         - name: {{ .Values.agent_name }}
           image: {{ .Values.image }}

--- a/canso-data-plane/canso-ai-agent/templates/serviceaccount.yaml
+++ b/canso-data-plane/canso-ai-agent/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.agent_name }}-sa
+  labels:
+    {{- include "ai-agent.labels" . | nindent 4 }}
+  annotations:
+    {{- if .Values.serviceAccount.annotations }}
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+    {{- end }}
+    {{- if .Values.serviceAccount.aws.enabled }}
+    eks.amazonaws.com/role-arn: {{ .Values.serviceAccount.aws.roleArn }}
+    {{- end }}

--- a/canso-data-plane/canso-ai-agent/values.yaml
+++ b/canso-data-plane/canso-ai-agent/values.yaml
@@ -102,3 +102,14 @@ readinessProbe:
   failureThreshold: 3
   ## @param readinessProbe.successThreshold Success threshold for readinessProbe
   successThreshold: 1
+
+## @section Service Account parameters
+serviceAccount:
+  ## @param serviceAccount.annotations Additional custom annotations for the ServiceAccount
+  annotations: {}
+  ## @subsection AWS IAM Role configuration
+  aws:
+    ## @param serviceAccount.aws.enabled Enable AWS IAM role
+    enabled: false
+    ## @param serviceAccount.aws.roleArn ARN of the IAM role to associate with the ServiceAccount
+    roleArn: ""


### PR DESCRIPTION

### Description

This Pr-

1. Adds a service account to the canso-ai-agent helm chart
2. Adds optional role Arn in the service account from values.yaml
3. Bumps the chart version from 0.1.2 to 0.1.3

### Testing

Tested on data plane

```
helm install /Users/mishrasandeep/Documents/canso-helm-charts/canso-helm-charts/canso-data-plane/canso-ai-agent -f agent-values.yaml --generate-name
```

**ServiceAccount** 
![image](https://github.com/user-attachments/assets/eeb6a418-e4cd-43b1-a34b-82b2533a9bec)

**Deployment**
![image](https://github.com/user-attachments/assets/d2b191d8-9d85-453b-afd2-777806870cd4)


### Deployment

1. Merge the PR
2. Verify github action new release
3. Veify installation with the new release

### Rollback

1. Revert the PR
2. Delete the released version from the index.yaml and the releases artifact