### PR TITLE
[NOJIRA] Set False init Jobs for rule evaluation

### DIFF
--- a/canso-data-plane/canso-rule-evaluation-service/Chart.yaml
+++ b/canso-data-plane/canso-rule-evaluation-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.11
+version: 0.0.12
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-rule-evaluation-service/README.md
+++ b/canso-data-plane/canso-rule-evaluation-service/README.md
@@ -77,11 +77,11 @@
 
 ### redis.initJob
 
-| Name                        | Description                   | Value  |
-| --------------------------- | ----------------------------- | ------ |
-| `redis.initJob.enabled`     | Enable the initialization job | `true` |
-| `redis.initJob.workflowKey` | The workflow key              | `""`   |
-| `redis.initJob.ruleEntries` | The rule entries              | `{}`   |
+| Name                        | Description                   | Value   |
+| --------------------------- | ----------------------------- | ------- |
+| `redis.initJob.enabled`     | Enable the initialization job | `false` |
+| `redis.initJob.workflowKey` | The workflow key              | `""`    |
+| `redis.initJob.ruleEntries` | The rule entries              | `{}`    |
 
 ### redis.persistence
 

--- a/canso-data-plane/canso-rule-evaluation-service/values.yaml
+++ b/canso-data-plane/canso-rule-evaluation-service/values.yaml
@@ -131,7 +131,7 @@ redis:
   ## @section redis.initJob
   initJob:
     ## @param redis.initJob.enabled Enable the initialization job
-    enabled: true  
+    enabled: false  
     ## @param redis.initJob.workflowKey The workflow key
     workflowKey: ""
     ## @param redis.initJob.ruleEntries The rule entries


### PR DESCRIPTION

### Description 
Set False Redis init jobs for Rule evaluation service.

### Testing
I have tested using helm template cmd

<details><summary> Helm Template Result </summary>
<p>

```
---
# Source: canso-rule-evaluation-service/templates/redis.yaml
---
apiVersion: v1
kind: Service
metadata:
  name: canso-rule-evaluation-service-redis
  namespace: rule-evaluation
  labels:
    app: canso-rule-evaluation-service-redis
spec:
  type: NodePort
  ports:
    - port: 6379
      targetPort: redis
      protocol: TCP
      name: redis
  selector:
    app: canso-rule-evaluation-service-redis
---
# Source: canso-rule-evaluation-service/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: canso-rule-evaluation-service
  namespace: rule-evaluation
  annotations:
    prometheus.io/scrape: "true"
    prometheus.io/port: "8000"
    prometheus.io/path: "/metrics"
    prometheus.io/scheme: "http"
spec:
  type: NodePort
  selector:
    app: canso-rule-evaluation-service
  ports:
  - name: http
    port: 80
    protocol: TCP
    targetPort: 8000
  - name: https
    port: 443
    protocol: TCP
    targetPort: 8000
---
# Source: canso-rule-evaluation-service/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: canso-rule-evaluation-service
  name: canso-rule-evaluation-service
  namespace: rule-evaluation
spec:
  selector:
    matchLabels:
      app: canso-rule-evaluation-service
  template:
    metadata:
      annotations:
        'consul.hashicorp.com/connect-inject': 'false'
      labels:
        app: canso-rule-evaluation-service
    spec:
      containers:
      - name: canso-rule-evaluation-service
        image: shaktimaanbot/rule-evaluation-service:v0.0.2-python-3.12-slim
        ports:
        - containerPort: 8000
        resources:
          limits:
            cpu: 400m
            memory: 500Mi
          requests:
            cpu: 50m
            memory: 100Mi
        env:
      imagePullSecrets:
        - name: docker-secret-cred
---
# Source: canso-rule-evaluation-service/templates/redis.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: canso-rule-evaluation-service-redis
  namespace: rule-evaluation
  labels:
    app: canso-rule-evaluation-service-redis
spec:
  replicas: 1
  selector:
    matchLabels:
      app: canso-rule-evaluation-service-redis
  template:
    metadata:
      labels:
        app: canso-rule-evaluation-service-redis
    spec:
      containers:
        - name: redis
          image: "redis:7.4.2"
          imagePullPolicy: IfNotPresent
          ports:
            - name: redis
              containerPort: 6379
              protocol: TCP
          env:
          resources:
            limits:
              cpu: 200m
              memory: 256Mi
            requests:
              cpu: 100m
              memory: 128Mi
---
# Source: canso-rule-evaluation-service/templates/hpa.yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: canso-rule-evaluation-service
  namespace: rule-evaluation
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: canso-rule-evaluation-service
  minReplicas: 1
  maxReplicas: 10
  metrics:
    - type: Resource
      resource:
        name: cpu
        target:
          type: Utilization
          averageUtilization: 80
    - type: Resource
      resource:
        name: memory
        target:
          type: Utilization
          averageUtilization: 80
---
# Source: canso-rule-evaluation-service/templates/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: canso-rule-evaluation-service-ing
  namespace: rule-evaluation
  labels:
    app: canso-rule-evaluation-service
  annotations:
    nginx.org/mergeable-ingress-type: minion
    nginx.org/rewrites: serviceName=canso-rule-evaluation-service rewrite=/v1/risk
spec:
  ingressClassName: nginx
  rules:
    - host: "*.com"
      http:
        paths:
          - backend:
              service:
                name: canso-rule-evaluation-service
                port:
                  number: 80
            path: /canso-rule-evaluation-service/v1/risk
            pathType: Prefix
---
# Source: canso-rule-evaluation-service/templates/external-secret.yaml
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: canso-rule-evaluation-service-es
  namespace: rule-evaluation
spec:
  refreshInterval: 1m
  secretStoreRef:
    name: secretstore-by-role
    kind: ClusterSecretStore
  target:
    name: docker-secret-cred 
    template:
      type: kubernetes.io/dockerconfigjson 
  data:
  - secretKey: .dockerconfigjson 
    remoteRef:
      key: canso-dockerhub-credentials 
      property: dockerhub

```

</p>
</details>

### Deployment
1. standard PR merge.

Rollback
1. Standard PR revert
2. delete new release from gh-pages
