### PR TITLE
[NOJIRA] Add metrics server for HPA

### DIFF
--- a/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.21
+version: 0.1.22
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-aws-eks-superchart/README.md
+++ b/canso-data-plane/canso-aws-eks-superchart/README.md
@@ -53,10 +53,9 @@
 
 ### Metrics Server Configuration
 
-| Name                    | Description                             | Value                        |
-| ----------------------- | --------------------------------------- | ---------------------------- |
-| `metricsServer.enabled` | Flag to enable Metrics Server           | `true`                       |
-| `metricsServer.args`    | Additional arguments for Metrics Server | `["--kubelet-insecure-tls"]` |
+| Name                    | Description                   | Value  |
+| ----------------------- | ----------------------------- | ------ |
+| `metricsServer.enabled` | Flag to enable Metrics Server | `true` |
 
 ### AWS Configs
 

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/metrics-server.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/metrics-server.yaml
@@ -31,12 +31,6 @@ spec:
         repoURL: https://kubernetes-sigs.github.io/metrics-server/
         chart: metrics-server
         targetRevision: 3.11.0
-        helm:
-          values: |
-            args:
-            {{- range .Values.metricsServer.args }}
-              - {{ . }}
-            {{- end }}
       syncPolicy:
         automated:
           prune: true

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/metrics-server.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/metrics-server.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.metricsServer.enabled }}
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: metrics-server
+  namespace: argocd
+  annotations:
+    helm.sh/hook: pre-install
+    helm.sh/hook-weight: "-19"
+    argocd.argoproj.io/sync-wave: "-5"
+  labels:
+    canso.ai/product-component: "infra-dependencies"
+    canso.ai/part-of: "superchart"
+    canso.ai/infra-component: "metrics-server"
+    canso.ai/infra-tag: "1000"
+spec:
+  generators:
+  - list:
+      elements:
+      - cluster: {{ .Values.clusterName }}
+        url: https://kubernetes.default.svc
+  template:
+    metadata:
+      name: metrics-server
+    spec:
+      project: {{ .Values.argocdProject }}
+      destination:
+        namespace: kube-system
+        server: https://kubernetes.default.svc
+      source:
+        repoURL: https://kubernetes-sigs.github.io/metrics-server/
+        chart: metrics-server
+        targetRevision: 3.11.0
+        helm:
+          values: |
+            args:
+            {{- range .Values.metricsServer.args }}
+              - {{ . }}
+            {{- end }}
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - ServerSideApply=true
+{{- end }}

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/metrics-server.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/metrics-server.yaml
@@ -30,7 +30,7 @@ spec:
       source:
         repoURL: https://kubernetes-sigs.github.io/metrics-server/
         chart: metrics-server
-        targetRevision: 3.11.0
+        targetRevision: 3.12.2
       syncPolicy:
         automated:
           prune: true

--- a/canso-data-plane/canso-aws-eks-superchart/values.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/values.yaml
@@ -131,10 +131,6 @@ metricsServer:
   ## @param metricsServer.enabled Flag to enable Metrics Server
   ##
   enabled: true
-  ## @param metricsServer.args Additional arguments for Metrics Server
-  ##
-  args:
-    - --kubelet-insecure-tls
 
 
 ####################################################

--- a/canso-data-plane/canso-aws-eks-superchart/values.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/values.yaml
@@ -58,13 +58,13 @@ queue_hostname: "rabbitmq-amqp.canso.ai"
 
 ## @skip queue_auth queue authentication username and password
 queue_auth:
-  password_encoded: ""
-  username: ""
+  password_encoded: "fgh"
+  username: "ghjj"
 
 ## @skip queues names of queue.
 queues:
-  incoming_queue: ""
-  outgoing_queue: ""
+  incoming_queue: "ghj"
+  outgoing_queue: "ghj"
 
 ####################################################
 ############### Tolerations & Affinity
@@ -120,6 +120,22 @@ canso:
       targetName: docker-secret-cred # name of kubernetes secret
       targetType: kubernetes.io/dockerconfigjson
       clusterSecretRole: secretstore-by-role # name of the ClusterSecret Role
+
+
+####################################################
+#################### Metrics Server
+####################################################
+
+## @section Metrics Server Configuration
+metricsServer:
+  ## @param metricsServer.enabled Flag to enable Metrics Server
+  ##
+  enabled: true
+  ## @param metricsServer.args Additional arguments for Metrics Server
+  ##
+  args:
+    - --kubelet-insecure-tls
+
 
 ####################################################
 ##################### AWS Configs

--- a/canso-data-plane/canso-aws-eks-superchart/values.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/values.yaml
@@ -58,13 +58,13 @@ queue_hostname: "rabbitmq-amqp.canso.ai"
 
 ## @skip queue_auth queue authentication username and password
 queue_auth:
-  password_encoded: "fgh"
-  username: "ghjj"
+  password_encoded: ""
+  username: ""
 
 ## @skip queues names of queue.
 queues:
-  incoming_queue: "ghj"
-  outgoing_queue: "ghj"
+  incoming_queue: ""
+  outgoing_queue: ""
 
 ####################################################
 ############### Tolerations & Affinity


### PR DESCRIPTION
### Description
I’ve added the metrics server to the ArgoApplication set and updated the values.yaml file with the appropriate configurations.

### Testing
Have tested using Helm cmd

<details><summary> Result </summary>
<p>

```yaml
# Source: canso-aws-eks-superchart/templates/aws/metrics-server.yaml
apiVersion: argoproj.io/v1alpha1
kind: ApplicationSet
metadata:
  name: metrics-server
  namespace: argocd
  annotations:
    helm.sh/hook: pre-install
    helm.sh/hook-weight: "-19"
    argocd.argoproj.io/sync-wave: "-5"
  labels:
    canso.ai/product-component: "infra-dependencies"
    canso.ai/part-of: "superchart"
    canso.ai/infra-component: "metrics-server"
    canso.ai/infra-tag: "1000"
spec:
  generators:
  - list:
      elements:
      - cluster: canso-dplane-v1
        url: https://kubernetes.default.svc
  template:
    metadata:
      name: metrics-server
    spec:
      project: canso-appsets
      destination:
        namespace: kube-system
        server: https://kubernetes.default.svc
      source:
        repoURL: https://kubernetes-sigs.github.io/metrics-server/
        chart: metrics-server
        targetRevision: 3.11.0
        helm:
          values: |
            args:
              - --kubelet-insecure-tls
      syncPolicy:
        automated:
          prune: true
          selfHeal: true
        syncOptions:
          - ServerSideApply=true
```

</p>
</details>


<img width="1080" alt="image" src="https://github.com/user-attachments/assets/c54126bf-e969-4979-b0eb-b1ef40de852e" />




### Deployment
1. Standard PR merge.

### Rollback
1. Standard PR revert.
2. Delete new releases in gh-pages.