### PR TITLE
Update dev agent cluster role to update and delete applications

### DIFF
--- a/canso-data-plane/canso-agent/Chart.yaml
+++ b/canso-data-plane/canso-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.19
+version: 0.1.20
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-agent/templates/clusterrole.yaml
+++ b/canso-data-plane/canso-agent/templates/clusterrole.yaml
@@ -13,7 +13,7 @@ rules:
     verbs: ["list", "watch"]
   - apiGroups: ["argoproj.io"]
     resources: ["applications", "applicationsets", "rollouts"]
-    verbs: ["get", "list", "watch", "create"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["sparkoperator.k8s.io"]
     resources: ["sparkapplications"]
     verbs: ["get", "list", "watch", "create", "delete"]

--- a/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.24
+version: 0.1.25
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
@@ -28,7 +28,7 @@ spec:
       source:
         repoURL: 'https://yugen-ai.github.io/canso-helm-charts'
         chart: canso-agent
-        targetRevision: 0.1.19
+        targetRevision: 0.1.20
         helm:
           values: |-
             config:


### PR DESCRIPTION
### Description

In line with 
- https://github.com/Yugen-ai/platform-dev-agent/pull/40 and 
- https://github.com/Yugen-ai/canso-cplane-agents-service/pull/13, 

the Canso dev agent needs to be able to update and delete argocd applications. This PR updates the dev agent cluster role to be able to do that.