### PR TITLE
AI Agent: Supply env variables as map instead of individual values

### DIFF
--- a/canso-data-plane/canso-ai-agent/Chart.yaml
+++ b/canso-data-plane/canso-ai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: canso-ai-agent
 description: A Helm chart for deploying AI agent services
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "0.0.1"

--- a/canso-data-plane/canso-ai-agent/templates/deployments.yaml
+++ b/canso-data-plane/canso-ai-agent/templates/deployments.yaml
@@ -19,18 +19,10 @@ spec:
         - name: {{ .Values.agent_name }}
           image: {{ .Values.image }}
           env:
-            - name: AGENT_NAME
-              value: {{ .Values.agent_name}}
-            - name: AGENT_URL
-              value:  {{ .Values.agent_url }}
-            - name: BROKER_URL
-              value: {{ .Values.broker_url }}
-            - name: CHECKPOINT_DB_HOST
-              value: {{ .Values.checkpoint_db_host }}
-            - name: CHECKPOINT_DB_PORT
-              value: '{{ .Values.checkpoint_db_port }}'
-            - name: CHECKPOINT_DB_PASSWORD
-              value: {{ .Values.checkpoint_db_password }}
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
 
           ports:
             - name: http

--- a/canso-data-plane/canso-ai-agent/values.yaml
+++ b/canso-data-plane/canso-ai-agent/values.yaml
@@ -9,24 +9,6 @@ image: "image"
 ## @param image_pull_secret image pull secret
 image_pull_secret : "image_pull_secret"
 
-## @param agent_name name of the ai agent
-agent_name: "agent_name"
-
-## @param agent_url url of the ai agent
-agent_url: "agent_url"
-
-## @param broker_url url of the broker through which to communicate to task server
-broker_url: "broker_url"
-
-## @param checkpoint_db_host checkpoint db host
-checkpoint_db_host: "checkpoint_db_host"
-
-## @param checkpoint_db_port checkpoint db port
-checkpoint_db_port: 5432
-
-## @param checkpoint_db_password checkpoint db password
-checkpoint_db_password: "checkpoint_db_password"
-
 ## @param nameOverride String to partially override ai-agent.fullname template (will maintain the release name)
 nameOverride: ""
 ## @param fullnameOverride String to fully override ai-agent.fullname template


### PR DESCRIPTION
### Description

This PR changes the way env variables are supplied to the AI Agent. 
Instead of supplying individual values, env variables are supplied as a map.
This prevents us needing to update the helm chart everytime we want to add a new env variable to the the AI agent.

### Deployment

Merge the PR

### Rollback

Revert the PR
