### PR TITLE
Upgraded Dev Agent version to support Latest Memory APIs

### DIFF
--- a/canso-data-plane/canso-agent/Chart.yaml
+++ b/canso-data-plane/canso-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.23
+version: 0.1.24
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-agent/README.md
+++ b/canso-data-plane/canso-agent/README.md
@@ -88,7 +88,7 @@
 | ---------------------------------------- | ------------------------- | ------------------------------------------------------------------------- |
 | `cansoAgent.deployment.image.repository` | repository for the image  | `shaktimaanbot/dev-agent-image`                                           |
 | `cansoAgent.deployment.image.pullPolicy` | Pull policy for the image | `Always`                                                                  |
-| `cansoAgent.deployment.image.tag`        | Tag for the image         | `sha256:fb98f3e3cc74c0b3949bd5299e6551643d6c95a1547d06fc2fa8ef5f7b68870c` |
+| `cansoAgent.deployment.image.tag`        | Tag for the image         | `sha256:2d95a3879f25c6ab4453cc31bb07ea66e73fc3695ffd496742dd45f0051c1f0d` |
 
 ### resources configuration
 
@@ -120,7 +120,7 @@
 | --------------------------------------------- | ------------------------- | ------------------------------------------------------------------------- |
 | `cansoAgent.proxyDeployment.image.repository` | repository for the image  | `shaktimaanbot/dev-agent-image`                                           |
 | `cansoAgent.proxyDeployment.image.pullPolicy` | Pull policy for the image | `Always`                                                                  |
-| `cansoAgent.proxyDeployment.image.tag`        | Tag for the image         | `sha256:0a019e6af71f32ab104dbf914f6a48b34a63cfcb0e1aeb0fa983e317675f89b5` |
+| `cansoAgent.proxyDeployment.image.tag`        | Tag for the image         | `sha256:9c40a87ce82f8834563c814afbc6a44b8daa3d063f2d1f9bfcc108f8ecd4bbf4` |
 
 ### resources configuration
 

--- a/canso-data-plane/canso-agent/values.yaml
+++ b/canso-data-plane/canso-agent/values.yaml
@@ -182,7 +182,7 @@ cansoAgent:
       pullPolicy: Always
       ## @param cansoAgent.deployment.image.tag Tag for the image
       ##
-      tag: "sha256:fb98f3e3cc74c0b3949bd5299e6551643d6c95a1547d06fc2fa8ef5f7b68870c"
+      tag: "sha256:2d95a3879f25c6ab4453cc31bb07ea66e73fc3695ffd496742dd45f0051c1f0d"
     ## @section resources configuration
     resources:
       ## @section resources limits configuration
@@ -239,7 +239,7 @@ cansoAgent:
       ##
       # Do not rely on the chart's `appVersion` since the proxy and the core agent
       # are on different positions in the semver progression.
-      tag: "sha256:0a019e6af71f32ab104dbf914f6a48b34a63cfcb0e1aeb0fa983e317675f89b5"
+      tag: "sha256:9c40a87ce82f8834563c814afbc6a44b8daa3d063f2d1f9bfcc108f8ecd4bbf4"
       
 
     ## @section resources configuration

--- a/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.28
+version: 0.1.29
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
@@ -28,7 +28,7 @@ spec:
       source:
         repoURL: 'https://yugen-ai.github.io/canso-helm-charts'
         chart: canso-agent
-        targetRevision: 0.1.23
+        targetRevision: 0.1.24
         helm:
           values: |-
             config:


### PR DESCRIPTION
### Description 

- This will release the latest code for Dev Agent with Memory Operation Strategy in PROD
    - https://github.com/Yugen-ai/canso-cplane-agents-service/pull/17

### Testing

- All the test results are attached here
    - https://github.com/Yugen-ai/platform-k8s-gitops-apps/pull/398


### Deployment
Standard PR merge.

### Rollback
Standard PR revert.