### PR TITLE
[NOJIRA] Add HPA for canso ai agent

### DIFF
--- a/canso-data-plane/canso-ai-agent/Chart.yaml
+++ b/canso-data-plane/canso-ai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: canso-ai-agent
 description: A Helm chart for deploying AI agent services
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "0.0.1"

--- a/canso-data-plane/canso-ai-agent/README.md
+++ b/canso-data-plane/canso-ai-agent/README.md
@@ -13,15 +13,14 @@ This Helm chart deploys an AI agent service to Kubernetes. It is currently in an
 
 ### Autoscaling parameters
 
-| Name                                                        | Description                                | Value         |
-| ----------------------------------------------------------- | ------------------------------------------ | ------------- |
-| `autoscaling.enabled`                                       | Enable autoscaling for ai-agent deployment | `true`        |
-| `autoscaling.minReplicas`                                   | Minimum number of replicas to scale back   | `1`           |
-| `autoscaling.maxReplicas`                                   | Maximum number of replicas to scale out    | `5`           |
-| `autoscaling.metrics[0].type`                               | Type of metric to use for scaling          | `Resource`    |
-| `autoscaling.metrics[0].resource.name`                      | Name of the resource to monitor            | `memory`      |
-| `autoscaling.metrics[0].resource.target.type`               | Type of scaling target                     | `Utilization` |
-| `autoscaling.metrics[0].resource.target.averageUtilization` | Target average utilization percentage      | `80`          |
+| Name                                            | Description                                      | Value  |
+| ----------------------------------------------- | ------------------------------------------------ | ------ |
+| `autoscaling.enabled`                           | Enable autoscaling for ai-agent deployment       | `true` |
+| `autoscaling.minReplicas`                       | Minimum number of replicas to scale back         | `1`    |
+| `autoscaling.maxReplicas`                       | Maximum number of replicas to scale out          | `5`    |
+| `autoscaling.targetCPUUtilizationPercentage`    | Target CPU utilization percentage                | `80`   |
+| `autoscaling.targetMemoryUtilizationPercentage` | Target memory utilization percentage             | `80`   |
+| `autoscaling.customMetrics`                     | Additional custom metrics for scaling (optional) | `[]`   |
 
 ### Resource Management
 

--- a/canso-data-plane/canso-ai-agent/templates/deployments.yaml
+++ b/canso-data-plane/canso-ai-agent/templates/deployments.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     {{- include "ai-agent.labels" . | nindent 4 }}
 spec:
-  replicas: {{ .Values.replicas }}
+  replicas: 1
   selector:
     matchLabels:
       {{- include "ai-agent.selectorLabels" . | nindent 6 }}

--- a/canso-data-plane/canso-ai-agent/templates/hpa.yaml
+++ b/canso-data-plane/canso-ai-agent/templates/hpa.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "ai-agent.fullname" . }}
+  labels:
+    {{- include "ai-agent.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "ai-agent.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+    {{- with .Values.autoscaling.customMetrics }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/canso-data-plane/canso-ai-agent/templates/hpa.yaml
+++ b/canso-data-plane/canso-ai-agent/templates/hpa.yaml
@@ -2,14 +2,14 @@
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: {{ include "ai-agent.fullname" . }}
+  name: {{ .Values.agent_name }}
   labels:
     {{- include "ai-agent.labels" . | nindent 4 }}
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: {{ include "ai-agent.fullname" . }}
+    name: {{ .Values.agent_name }}
   minReplicas: {{ .Values.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.autoscaling.maxReplicas }}
   metrics:

--- a/canso-data-plane/canso-ai-agent/values.yaml
+++ b/canso-data-plane/canso-ai-agent/values.yaml
@@ -1,8 +1,5 @@
 # values.yaml
 
-## @param replicas Number of replicas to deploy
-replicas: 1
-
 ## @param image full image name including tag
 image: "image"
 
@@ -29,20 +26,12 @@ autoscaling:
   minReplicas: 1
   ## @param autoscaling.maxReplicas Maximum number of replicas to scale out
   maxReplicas: 5
-  ## @subsection autoscaling.metrics Metrics to use for scaling (only type Resource is supported)
-  metrics:
-    ## @param autoscaling.metrics[0].type Type of metric to use for scaling
-    - type: Resource
-      ## @subsection autoscaling.metrics[0].resource Resource metrics to use for scaling
-      resource:
-        ## @param autoscaling.metrics[0].resource.name Name of the resource to monitor
-        name: memory
-        ## @subsection autoscaling.metrics[0].resource.target Target for the resource metric
-        target:
-          ## @param autoscaling.metrics[0].resource.target.type Type of scaling target
-          type: Utilization
-          ## @param autoscaling.metrics[0].resource.target.averageUtilization Target average utilization percentage
-          averageUtilization: 80
+  ## @param autoscaling.targetCPUUtilizationPercentage Target CPU utilization percentage
+  targetCPUUtilizationPercentage: 80
+  ## @param autoscaling.targetMemoryUtilizationPercentage Target memory utilization percentage
+  targetMemoryUtilizationPercentage: 80
+  ## @param autoscaling.customMetrics Additional custom metrics for scaling (optional)
+  customMetrics: []
 
 ## @section Resource Management
 resources:


### PR DESCRIPTION
### Descriptions

This PR adds HPA to the AI Agent, allowing it to automatically adjust the number of pods based on CPU and memory usage. This improvement boosts resource efficiency and enhances service reliability during fluctuating workloads.

### Testing

I have tested using helm template cmd.

<details><summary> Helm Template Result </summary>
<p>

```yaml
---
# Source: canso-ai-agent/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: -sa
  labels:
    helm.sh/chart: canso-ai-agent-0.1.5
    app.kubernetes.io/name: canso-ai-agent
    app.kubernetes.io/instance: release-name
    canso.ai/agent-name : 
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
---
# Source: canso-ai-agent/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: 
  labels:
    helm.sh/chart: canso-ai-agent-0.1.5
    app.kubernetes.io/name: canso-ai-agent
    app.kubernetes.io/instance: release-name
    canso.ai/agent-name : 
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
spec:
  type: NodePort
  ports:
    - port: 8080
      targetPort: http
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/name: canso-ai-agent
    app.kubernetes.io/instance: release-name
    canso.ai/agent-name :
---
# Source: canso-ai-agent/templates/deployments.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: 
  labels:
    helm.sh/chart: canso-ai-agent-0.1.5
    app.kubernetes.io/name: canso-ai-agent
    app.kubernetes.io/instance: release-name
    canso.ai/agent-name : 
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: canso-ai-agent
      app.kubernetes.io/instance: release-name
      canso.ai/agent-name : 
  template:
    metadata:
      labels:
        app.kubernetes.io/name: canso-ai-agent
        app.kubernetes.io/instance: release-name
        canso.ai/agent-name : 
    spec:
      serviceAccountName: -sa
      containers:
        - name: 
          image: image
          env:

          ports:
            - name: http
              containerPort: 8080
              protocol: TCP
          resources:
            limits: {}
            requests: {}
      imagePullSecrets:
        - name: image_pull_secret
---
# Source: canso-ai-agent/templates/hpa.yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: 
  labels:
    helm.sh/chart: canso-ai-agent-0.1.5
    app.kubernetes.io/name: canso-ai-agent
    app.kubernetes.io/instance: release-name
    canso.ai/agent-name : 
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: 
  minReplicas: 1
  maxReplicas: 5
  metrics:
    - type: Resource
      resource:
        name: cpu
        target:
          type: Utilization
          averageUtilization: 80
    - type: Resource
      resource:
        name: memory
        target:
          type: Utilization
          averageUtilization: 80


```

</p>
</details>

### Deployment

1. Standard PR merge.
2. Update chart version in [cplane-agent-service](https://github.com/Yugen-ai/canso-cplane-agents-service/blob/b6a50449d202960ce60ee458b1dda03c8a4a3478/src/static/templates/ai_agent_argo_application.yaml.j2#L21).

### Rollback

1. Stndard PR revert.
2. Delete latest Release on gh-pages.