### PR TITLE
New Canso Dev Agent Helm Release (Alpha version)

### DIFF
--- a/canso-data-plane/canso-agent/Chart.yaml
+++ b/canso-data-plane/canso-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.26-beta
+version: 0.1.26
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-agent/Chart.yaml
+++ b/canso-data-plane/canso-agent/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.26
+version: 0.1.26-beta
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-agent/Chart.yaml
+++ b/canso-data-plane/canso-agent/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.25
+version: 0.1.26-alpha
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.0.7-python-3.13-slim"
+appVersion: "v0.1.rc1-python-3.13-slim"

--- a/canso-data-plane/canso-agent/Chart.yaml
+++ b/canso-data-plane/canso-agent/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.26-alpha
+version: 0.1.26
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.1.rc1-python-3.13-slim"
+appVersion: "v0.1.0-python-3.13-slim"

--- a/canso-data-plane/canso-agent/README.md
+++ b/canso-data-plane/canso-agent/README.md
@@ -84,32 +84,32 @@
 
 ### Image Configuration  
 
-| Name                                     | Description               | Value                                                                     |
-| ---------------------------------------- | ------------------------- | ------------------------------------------------------------------------- |
-| `cansoAgent.deployment.image.repository` | repository for the image  | `shaktimaanbot/dev-agent-image`                                           |
-| `cansoAgent.deployment.image.pullPolicy` | Pull policy for the image | `Always`                                                                  |
-| `cansoAgent.deployment.image.tag`        | Tag for the image         | `sha256:416a53749a1326c0b2a62732c78ea2f09482c462fd2e3d5cc4b01cc14d067c73` |
+| Name                                     | Description               | Value                           |
+| ---------------------------------------- | ------------------------- | ------------------------------- |
+| `cansoAgent.deployment.image.repository` | repository for the image  | `shaktimaanbot/dev-agent-image` |
+| `cansoAgent.deployment.image.pullPolicy` | Pull policy for the image | `Always`                        |
+| `cansoAgent.deployment.image.tag`        | Tag for the image         | `v0.1.rc1-python-3.13-slim`     |
 
 ### resources configuration
 
 
 ### resources limits configuration
 
-| Name                                                       | Description                                                                                 | Value   |
-| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------- | ------- |
-| `cansoAgent.deployment.resources.limits.cpu`               | CPU limits for the Canso Agent container. Strongly recommend to not decrease.               | `800m`  |
-| `cansoAgent.deployment.resources.limits.memory`            | Memory limits for the Canso Agent container. Strongly recommend to not decrease.            | `512Mi` |
-| `cansoAgent.deployment.resources.limits.ephemeral-storage` | Ephemeral storage limits for the Canso Agent container. Strongly recommend to not decrease. | `512Mi` |
+| Name                                                       | Description                                                                                 | Value    |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------- | -------- |
+| `cansoAgent.deployment.resources.limits.cpu`               | CPU limits for the Canso Agent container. Strongly recommend to not decrease.               | `2400m`  |
+| `cansoAgent.deployment.resources.limits.memory`            | Memory limits for the Canso Agent container. Strongly recommend to not decrease.            | `2000Mi` |
+| `cansoAgent.deployment.resources.limits.ephemeral-storage` | Ephemeral storage limits for the Canso Agent container. Strongly recommend to not decrease. | `512Mi`  |
 
 ### resources requests configuration
 
-| Name                                                         | Description                                                                                   | Value   |
-| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------- | ------- |
-| `cansoAgent.deployment.resources.requests.cpu`               | CPU requests for the Canso Agent container. Strongly recommend to not decrease.               | `500m`  |
-| `cansoAgent.deployment.resources.requests.memory`            | Memory requests for the Canso Agent container. Strongly recommend to not decrease.            | `256Mi` |
-| `cansoAgent.deployment.resources.requests.ephemeral-storage` | Ephemeral storage requests for the Canso Agent container. Strongly recommend to not decrease. | `256Mi` |
-| `cansoAgent.deployment.enableEnv`                            | Whether environment variables are enabled                                                     | `true`  |
-| `cansoAgent.deployment.enableEnvSecrets`                     | Whether environment secrets are enabled                                                       | `false` |
+| Name                                                         | Description                                                                                   | Value    |
+| ------------------------------------------------------------ | --------------------------------------------------------------------------------------------- | -------- |
+| `cansoAgent.deployment.resources.requests.cpu`               | CPU requests for the Canso Agent container. Strongly recommend to not decrease.               | `1600m`  |
+| `cansoAgent.deployment.resources.requests.memory`            | Memory requests for the Canso Agent container. Strongly recommend to not decrease.            | `1024Mi` |
+| `cansoAgent.deployment.resources.requests.ephemeral-storage` | Ephemeral storage requests for the Canso Agent container. Strongly recommend to not decrease. | `256Mi`  |
+| `cansoAgent.deployment.enableEnv`                            | Whether environment variables are enabled                                                     | `true`   |
+| `cansoAgent.deployment.enableEnvSecrets`                     | Whether environment secrets are enabled                                                       | `false`  |
 
 ### Proxy Deployment Configurations
 
@@ -145,9 +145,10 @@
 
 ### redis configuration
 
-| Name                     | Description | Value         |
-| ------------------------ | ----------- | ------------- |
-| `cansoAgent.redis.image` | redis image | `redis:7.2.5` |
+| Name                           | Description        | Value         |
+| ------------------------------ | ------------------ | ------------- |
+| `cansoAgent.redis.image`       | redis image        | `redis:7.2.5` |
+| `cansoAgent.redis.servicePort` | redis service port | `6379`        |
 
 ### Autoscaling Configuration
 

--- a/canso-data-plane/canso-agent/README.md
+++ b/canso-data-plane/canso-agent/README.md
@@ -88,7 +88,7 @@
 | ---------------------------------------- | ------------------------- | ------------------------------- |
 | `cansoAgent.deployment.image.repository` | repository for the image  | `shaktimaanbot/dev-agent-image` |
 | `cansoAgent.deployment.image.pullPolicy` | Pull policy for the image | `Always`                        |
-| `cansoAgent.deployment.image.tag`        | Tag for the image         | `v0.1.rc1-python-3.13-slim`     |
+| `cansoAgent.deployment.image.tag`        | Tag for the image         | `v0.1.0-python-3.13-slim`       |
 
 ### resources configuration
 

--- a/canso-data-plane/canso-agent/templates/celery-worker-deployment.yaml
+++ b/canso-data-plane/canso-agent/templates/celery-worker-deployment.yaml
@@ -56,8 +56,8 @@ spec:
           {{- end }}
         {{- end }}
         
-        command: ["/bin/sh", "-c"]
-        args: ["cd src && celery -A celery_app worker --loglevel=info"]
+        command: ["python"]
+        args: ["/app/celery_worker.py"]
       {{- if .Values.cansoAgent.external_secret.enabled }}
       imagePullSecrets:
         - name: {{ .Values.cansoAgent.external_secret.target_secret_name }}

--- a/canso-data-plane/canso-agent/templates/celery-worker-deployment.yaml
+++ b/canso-data-plane/canso-agent/templates/celery-worker-deployment.yaml
@@ -37,7 +37,7 @@ spec:
           - name: CELERY_BROKER_URL
             value: {{ printf "redis://%s.%s.svc.cluster.local:%d/%d" (include "canso-agent-redis.fullname" .) .Release.Namespace ( .Values.cansoAgent.redis.servicePort | int ) ( .Values.cansoAgent.redis.database | default 0 | int ) }}
           - name: CELERY_BACKEND_URL
-            value: {{ printf "redis://%s.%s.svc.cluster.local:%d/%d" (include "canso-agent-redis.fullname" .) .Release.Namespace ( .Values.cansoAgent.redis.servicePort | int ) ( .Values.cansoAgent.redis.database | default 0 | int) }}
+            value: {{ printf "redis://%s.%s.svc.cluster.local:%d/%d" (include "canso-agent-redis.fullname" .) .Release.Namespace ( .Values.cansoAgent.redis.servicePort | int ) ( .Values.cansoAgent.redis.database | default 0 | int ) }}
 
           {{- range .Values.cansoAgent.deployment.env }}
           - name: {{ .name }}

--- a/canso-data-plane/canso-agent/templates/celery-worker-deployment.yaml
+++ b/canso-data-plane/canso-agent/templates/celery-worker-deployment.yaml
@@ -34,6 +34,10 @@ spec:
             value: {{ .Values.config.outgoing_queue }}
           - name: INCOMING_QUEUE
             value: {{ .Values.config.incoming_queue }}
+          - name: CELERY_BROKER_URL
+            value: {{ printf "redis://%s.%s.svc.cluster.local:%d/%d" (include "canso-agent-redis.fullname" .) .Release.Namespace ( .Values.cansoAgent.redis.servicePort | int ) ( .Values.cansoAgent.redis.database | default 0 | int ) }}
+          - name: CELERY_BACKEND_URL
+            value: {{ printf "redis://%s.%s.svc.cluster.local:%d/%d" (include "canso-agent-redis.fullname" .) .Release.Namespace ( .Values.cansoAgent.redis.servicePort | int ) ( .Values.cansoAgent.redis.database | default 0 | int) }}
 
           {{- range .Values.cansoAgent.deployment.env }}
           - name: {{ .name }}

--- a/canso-data-plane/canso-agent/templates/deployment.yaml
+++ b/canso-data-plane/canso-agent/templates/deployment.yaml
@@ -53,6 +53,10 @@ spec:
             value: {{ .Values.config.outgoing_queue }}
           - name: INCOMING_QUEUE
             value: {{ .Values.config.incoming_queue }}
+          - name: CELERY_BROKER_URL
+            value: {{ printf "redis://%s.%s.svc.cluster.local:%d/%d" (include "canso-agent-redis.fullname" .) .Release.Namespace ( .Values.cansoAgent.redis.servicePort | int ) ( .Values.cansoAgent.redis.database | default 0 | int ) }}
+          - name: CELERY_BACKEND_URL
+            value: {{ printf "redis://%s.%s.svc.cluster.local:%d/%d" (include "canso-agent-redis.fullname" .) .Release.Namespace ( .Values.cansoAgent.redis.servicePort | int ) ( .Values.cansoAgent.redis.database | default 0 | int ) }}
 
           {{- range .Values.cansoAgent.deployment.env }}
           - name: {{ .name }}

--- a/canso-data-plane/canso-agent/templates/redis.yaml
+++ b/canso-data-plane/canso-agent/templates/redis.yaml
@@ -7,7 +7,7 @@ metadata:
     app: {{ include "canso-agent-redis.fullname" . }}
 spec:
   ports:
-  - port: 6379
+  - port: {{ .Values.cansoAgent.redis.servicePort | default 6379 }}
     name: {{ include "canso-agent-redis.fullname" . }}
   selector:
     app: {{ include "canso-agent-redis.fullname" . }}

--- a/canso-data-plane/canso-agent/values.yaml
+++ b/canso-data-plane/canso-agent/values.yaml
@@ -23,10 +23,10 @@ config:
   ## @param config.queue_password rabbitmq password
   ##
   queue_password: "" # THIS VALUE IS MANDATORY FOR CANSO SETUP (Reach out to the Canso Team)
-  ## @param config.outgoing_queue rabbitmq password
+  ## @param config.outgoing_queue Outgoing Queue
   ##
   outgoing_queue: "" # THIS VALUE IS MANDATORY FOR CANSO SETUP (Reach out to the Canso Team)
-  ## @param config.incoming_queue rabbitmq password
+  ## @param config.incoming_queue Incoming Queue
   ##
   incoming_queue: "" # THIS VALUE IS MANDATORY FOR CANSO SETUP (Reach out to the Canso Team)
   ## @param config.airflow_interval_minutes interval to get airflow job health metrics.

--- a/canso-data-plane/canso-agent/values.yaml
+++ b/canso-data-plane/canso-agent/values.yaml
@@ -182,7 +182,7 @@ cansoAgent:
       pullPolicy: Always
       ## @param cansoAgent.deployment.image.tag Tag for the image
       ##
-      tag: "sha256:416a53749a1326c0b2a62732c78ea2f09482c462fd2e3d5cc4b01cc14d067c73"
+      tag: "v0.1.rc1-python-3.13-slim" # !!!CAUTION!!! - RELEASE CANDIDATE, DO NOT USE IN PRODUCTION!!!
     ## @section resources configuration
     resources:
       ## @section resources limits configuration
@@ -190,10 +190,10 @@ cansoAgent:
       limits:
         ## @param cansoAgent.deployment.resources.limits.cpu CPU limits for the Canso Agent container. Strongly recommend to not decrease.
         ##
-        cpu: 800m
+        cpu: 2400m
         ## @param cansoAgent.deployment.resources.limits.memory Memory limits for the Canso Agent container. Strongly recommend to not decrease.
         ##
-        memory: 512Mi
+        memory: 2000Mi
         ## @param cansoAgent.deployment.resources.limits.ephemeral-storage Ephemeral storage limits for the Canso Agent container. Strongly recommend to not decrease.
         ##
         ephemeral-storage: 512Mi
@@ -202,10 +202,10 @@ cansoAgent:
       requests:
         ## @param cansoAgent.deployment.resources.requests.cpu CPU requests for the Canso Agent container. Strongly recommend to not decrease.
         ##
-        cpu: 500m
+        cpu: 1600m
         ## @param cansoAgent.deployment.resources.requests.memory Memory requests for the Canso Agent container. Strongly recommend to not decrease.
         ##
-        memory: 256Mi
+        memory: 1024Mi
         ## @param cansoAgent.deployment.resources.requests.ephemeral-storage Ephemeral storage requests for the Canso Agent container. Strongly recommend to not decrease.
         ##
         ephemeral-storage: 256Mi

--- a/canso-data-plane/canso-agent/values.yaml
+++ b/canso-data-plane/canso-agent/values.yaml
@@ -182,7 +182,7 @@ cansoAgent:
       pullPolicy: Always
       ## @param cansoAgent.deployment.image.tag Tag for the image
       ##
-      tag: "v0.1.rc1-python-3.13-slim" # !!!CAUTION!!! - RELEASE CANDIDATE, DO NOT USE IN PRODUCTION!!!
+      tag: "v0.1.0-python-3.13-slim"
     ## @section resources configuration
     resources:
       ## @section resources limits configuration

--- a/canso-data-plane/canso-agent/values.yaml
+++ b/canso-data-plane/canso-agent/values.yaml
@@ -290,6 +290,16 @@ cansoAgent:
     ## @param cansoAgent.redis.image redis image
     ##
     image: redis:7.2.5
+    ## @param cansoAgent.redis.servicePort redis service port
+    ##
+    servicePort: 6379
+    # Since no `targetPort` is set in the Redis Service, `port` and `containerPort`
+    # are automatically aligned. If `port` is set and `targetPort` is omitted, then
+    # targetPort`` is automatically set to `port`
+    # `6379` could have been hardcoded in the template
+    # but we need this value to create the FQDN which is part of the `CELERY_BROKER_URL`
+    # and `CELERY_BACKEND_URL` env variables used the Celery App in the Canso Dev Agent
+    # Core.
   
   ## @section Autoscaling Configuration
   ##

--- a/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.30
+version: 0.1.31
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.31
+version: 0.1.30
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
@@ -28,7 +28,7 @@ spec:
       source:
         repoURL: 'https://yugen-ai.github.io/canso-helm-charts'
         chart: canso-agent
-        targetRevision: 0.1.25
+        targetRevision: 0.1.26
         helm:
           values: |-
             config:

--- a/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
+++ b/canso-data-plane/canso-aws-eks-superchart/templates/aws/canso-agent.yaml
@@ -28,7 +28,7 @@ spec:
       source:
         repoURL: 'https://yugen-ai.github.io/canso-helm-charts'
         chart: canso-agent
-        targetRevision: 0.1.26
+        targetRevision: 0.1.25
         helm:
           values: |-
             config:


### PR DESCRIPTION
### Context

See 

- https://github.com/Yugen-ai/platform-dev-agent/issues/44
- https://github.com/Yugen-ai/platform-dev-agent/pull/45

### Description
TBU

TODOs
- [ ] Update Superchart

### Additional Changes

A longstanding issue we have had in the Canso Dev Agent is that Celery broker and backend URLs have been hardcoded in the application. Since we run 2 Dev agents in the data plane (one for staging & prod each), the hardcoded Broker & Backend URLs cause the staging Dev Agent to interact with the Prod celery & redis.

This caused issues when the Dev Agent refactor was being tested. We had to hardcode the URLs to the staging values to then see the logs in the Dev Agent and Celery PODs.

This PR makes a longer term fix so that we can manage both deployments of Dev Agents in the Data Plane independently. In both the Celery Worker & Dev Agent Deployment, we're adding CELERY_BROKER_URL and CELERY_BACKEND_URL as env variables. The logic to get these values in a reliable fashion uses Go's templating functionality and is explained below

- Overall format of the value is `"redis://%s.%s.svc.cluster.local:%d/%d"`
- The 1st element is the service name, which we get from the helper `canso-agent-celery.fullname`. This has been defined already in _helpers and is used by the Redis Service as well. Using the same helper ensures alignment.
- The 2nd element is the namespace, which is taken from the Helm chart's release
- The 3rd element is the Redis Service port. Now, this was hardcoded to 6379 in Redis template. To ensure a single source of truth, a `cansoAgent.redis` now has a param `servicePort`. This is now used in the Redis Service as well as as the 3rd element, thereby ensuring alignment
- The 4th value is 0 in all cases we've seen. It can be gotten from `.Values.cansoAgent.redis.database` and defaults to 0. To keep things simple, haven't added `database` in values.yaml, so the default 0 will get picked always.
- `servicePort` is cast as integer (3rd element) - `( .Values.cansoAgent.redis.servicePort | int )`
- `database` is cast as integer (4th element) - `( .Values.cansoAgent.redis.database | default 0 | int )`

Helm template commands were run to render the values and check if the result look good. The results will
be attached in the main PR for greater visibility.

## Tests
- See https://github.com/Yugen-ai/canso-helm-charts/pull/86#issuecomment-2768758581
- Helm Upgrade in staging from feature branch

```sh
(base) ➜  canso-helm-charts git:(issue-44-dev-agent) ✗ helm upgrade canso-agent-stage ./canso-data-plane/canso-agent/ --namespace canso-agent-stage
Release "canso-agent-stage" has been upgraded. Happy Helming!
NAME: canso-agent-stage
LAST DEPLOYED: Tue Apr  1 19:48:57 2025
NAMESPACE: canso-agent-stage
STATUS: deployed
REVISION: 50
TEST SUITE: None
```

Both the Canso Dev agent & Celery PODs were stable after the upgrade. `CELERY_BROKER_URL` and `CELERY_BACKEND_URL` are now set as env variables with the expected values.


cc @Yugen-ai/platform-engineering 