### PR TITLE
[NOJIRA] Added resources for AI agent pod

### DIFF
--- a/canso-data-plane/canso-ai-agent/Chart.yaml
+++ b/canso-data-plane/canso-ai-agent/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: canso-ai-agent
 description: A Helm chart for deploying AI agent services
 type: application
-version: 0.1.5
+version: 0.1.6
 appVersion: "0.0.1"

--- a/canso-data-plane/canso-ai-agent/values.yaml
+++ b/canso-data-plane/canso-ai-agent/values.yaml
@@ -33,16 +33,14 @@ autoscaling:
   ## @param autoscaling.customMetrics Additional custom metrics for scaling (optional)
   customMetrics: []
 
-## @section Resource Management
+## @skip deployment.resources The resources requests and limits for the container.
 resources:
-  ## @param resources.limits The resources limits for the ai-agent container
-  limits: {}
-    # cpu: 100m
-    # memory: 128Mi
-  ## @param resources.requests The requested resources for the ai-agent container
-  requests: {}
-    # cpu: 100m
-    # memory: 128Mi
+  limits:
+    cpu: "500m"
+    memory: "600Mi"
+  requests:
+    cpu: "100m"
+    memory: "200Mi"
 
 ## @section Liveness and Readiness Probes
 ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/


### PR DESCRIPTION
Descriptions
This PR adds resources to the AI Agent, allowing it to automatically adjust the number of pods based on CPU and memory usage. This improvement boosts resource efficiency and enhances service reliability during fluctuating workloads.

Testing
I have tested using helm template cmd.

<details><summary> Helm Template Result </summary>
<p>

```yaml
---
# Source: canso-ai-agent/templates/serviceaccount.yaml
apiVersion: v1
kind: ServiceAccount
metadata:
  name: -sa
  labels:
    helm.sh/chart: canso-ai-agent-0.1.5
    app.kubernetes.io/name: canso-ai-agent
    app.kubernetes.io/instance: release-name
    canso.ai/agent-name : 
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
  annotations:
---
# Source: canso-ai-agent/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: 
  labels:
    helm.sh/chart: canso-ai-agent-0.1.5
    app.kubernetes.io/name: canso-ai-agent
    app.kubernetes.io/instance: release-name
    canso.ai/agent-name : 
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
spec:
  type: NodePort
  ports:
    - port: 8080
      targetPort: http
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/name: canso-ai-agent
    app.kubernetes.io/instance: release-name
    canso.ai/agent-name :
---
# Source: canso-ai-agent/templates/deployments.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: 
  labels:
    helm.sh/chart: canso-ai-agent-0.1.5
    app.kubernetes.io/name: canso-ai-agent
    app.kubernetes.io/instance: release-name
    canso.ai/agent-name : 
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: canso-ai-agent
      app.kubernetes.io/instance: release-name
      canso.ai/agent-name : 
  template:
    metadata:
      labels:
        app.kubernetes.io/name: canso-ai-agent
        app.kubernetes.io/instance: release-name
        canso.ai/agent-name : 
    spec:
      serviceAccountName: -sa
      containers:
        - name: 
          image: image
          env:

          ports:
            - name: http
              containerPort: 8080
              protocol: TCP
          resources:
            limits:
              cpu: 500m
              memory: 600Mi
            requests:
              cpu: 100m
              memory: 200Mi
      imagePullSecrets:
        - name: image_pull_secret
---
# Source: canso-ai-agent/templates/hpa.yaml
apiVersion: autoscaling/v2
kind: HorizontalPodAutoscaler
metadata:
  name: 
  labels:
    helm.sh/chart: canso-ai-agent-0.1.5
    app.kubernetes.io/name: canso-ai-agent
    app.kubernetes.io/instance: release-name
    canso.ai/agent-name : 
    app.kubernetes.io/version: "0.0.1"
    app.kubernetes.io/managed-by: Helm
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name: 
  minReplicas: 1
  maxReplicas: 5
  metrics:
    - type: Resource
      resource:
        name: cpu
        target:
          type: Utilization
          averageUtilization: 80
    - type: Resource
      resource:
        name: memory
        target:
          type: Utilization
          averageUtilization: 80

```

</p>
</details>

### Deployment
1. Standard PR merge.
2. Update chart version in [cplane-agent-service](https://github.com/Yugen-ai/canso-cplane-agents-service/blob/b6a50449d202960ce60ee458b1dda03c8a4a3478/src/static/templates/ai_agent_argo_application.yaml.j2#L21).

### Rollback

1. Stndard PR revert.
2. Delete latest Release on gh-pages.