### PR TITLE
First Helm release of the Canso Fraud Analyst Service (AI Agent based Investigations)

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Install readme-generator-for-helm
         run: npm install -g @bitnami/readme-generator-for-helm
       - name: Checkout charts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{github.event.pull_request.head.ref}}
           repository: ${{github.event.pull_request.head.repo.full_name}}

--- a/canso-data-plane/canso-fraud-analyst-service/.helmignore
+++ b/canso-data-plane/canso-fraud-analyst-service/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/canso-data-plane/canso-fraud-analyst-service/Chart.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.0.1rc1-python-3.13-slim"
+appVersion: "core-v0.0.1rc1-python-3.13-slim"

--- a/canso-data-plane/canso-fraud-analyst-service/Chart.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: canso-fraud-analyst-service
+description: Canso Fraud Analyst Service - AI copilot for Fraud Investigations
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v0.0.1rc1-python-3.13-slim"

--- a/canso-data-plane/canso-fraud-analyst-service/templates/NOTES.txt
+++ b/canso-data-plane/canso-fraud-analyst-service/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "canso-fraud-analyst-service.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "canso-fraud-analyst-service.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "canso-fraud-analyst-service.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "canso-fraud-analyst-service.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/canso-data-plane/canso-fraud-analyst-service/templates/_helpers.tpl
+++ b/canso-data-plane/canso-fraud-analyst-service/templates/_helpers.tpl
@@ -1,0 +1,76 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "canso-fraud-analyst-service.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "canso-fraud-analyst-service.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "canso-fraud-analyst-service.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "canso-fraud-analyst-service.labels" -}}
+helm.sh/chart: {{ include "canso-fraud-analyst-service.chart" . }}
+{{ include "canso-fraud-analyst-service.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "canso-fraud-analyst-service.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "canso-fraud-analyst-service.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "canso-fraud-analyst-service.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "canso-fraud-analyst-service.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+
+{{/*
+Create the image path for the passed in image field
+Credits - https://blog.andyserver.com/2021/09/adding-image-digest-references-to-your-helm-charts/
+*/}}
+{{- define "canso-fraud-analyst-service.image" -}}
+{{- $tag := .tag -}}
+{{- if eq (substr 0 7 $tag) "sha256:" -}}
+{{- printf "%s@%s" .repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" .repository $tag -}}
+{{- end -}}
+{{- end -}}

--- a/canso-data-plane/canso-fraud-analyst-service/templates/configmap.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "canso-fraud-analyst-service.fullname" . }}-cm
+  labels:
+    {{- include "canso-fraud-analyst-service.labels" . | nindent 4 }}
+data:
+  data_et_conn_configs.json: {{ .Values.configMaps.fraudAnalyst.tenantDataETConnConfigs | toJson | quote }}
+  data_et_configs.json: {{ .Values.configMaps.fraudAnalyst.tenantDataETConfigs | toJson | quote }}

--- a/canso-data-plane/canso-fraud-analyst-service/templates/deployment.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/templates/deployment.yaml
@@ -63,6 +63,12 @@ spec:
                   key: milvus-password #FIXME: Incorrect
             - name: CANSO_LLM_CONFIGS
               value: {{ .Values.env.llmConfigs | toJson | quote }}
+            - name: TENANT_CONFIG_ROOT_PATH
+              value: "/opt/canso-fraud-analyst-service/app/tenants"
+            - name: TENANT_DATA_ET_CONN_CONFIG_PATH
+              value: "/opt/canso-fraud-analyst-service/app/tenants/data_et_conn_configs.json"
+            - name: TENANT_DATA_ET_CONFIG_PATH
+              value: "/opt/canso-fraud-analyst-service/app/tenants/data_et_configs.json"
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}
@@ -76,7 +82,7 @@ spec:
           volumeMounts:
             # ConfigMap volume mount
             - name: tenant-resources 
-              mountPath: /app/tenants #TODO: Discuss & test in docker compose
+              mountPath: /opt/canso-fraud-analyst-service/app/tenants #TODO: Discuss & test in docker compose
               readOnly: true
           {{- with .Values.volumeMounts }}
           volumeMounts:

--- a/canso-data-plane/canso-fraud-analyst-service/templates/deployment.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/templates/deployment.yaml
@@ -1,0 +1,105 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "canso-fraud-analyst-service.fullname" . }}
+  labels:
+    {{- include "canso-fraud-analyst-service.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "canso-fraud-analyst-service.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "canso-fraud-analyst-service.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "canso-fraud-analyst-service.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: CANSO_INVESTIGATIONS_HOST
+              value: {{ .Values.env.db.cansoInvestigations.host | quote }}
+            - name: CANSO_INVESTIGATIONS_PORT
+              value: {{ .Values.env.db.cansoInvestigations.port | quote }}
+            - name: CANSO_INVESTIGATIONS_DATABASE
+              value: {{ .Values.env.db.cansoInvestigations.database | quote }}
+            - name: CANSO_INVESTIGATIONS_USER
+              value: {{ .Values.env.db.cansoInvestigations.user | quote }}
+            - name: CANSO_INVESTIGATIONS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-secrets #FIXME: Incorrect
+                  key: postgres-password #FIXME: Incorrect
+            - name: CANSO_VECTOR_DB_HOST
+              value: {{ .Values.env.vectorDB.cansoCommon.host | quote }}
+            - name: CANSO_VECTOR_DB_PORT
+              value: {{ .Values.env.vectorDB.cansoCommon.port | quote }}
+            - name: CANSO_VECTOR_DB_USER
+              value: {{ .Values.env.vectorDB.cansoCommon.user | quote }}
+            - name: CANSO_VECTOR_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: db-secrets #FIXME: Incorrect
+                  key: milvus-password #FIXME: Incorrect
+            - name: CANSO_LLM_CONFIGS
+              value: {{ .Values.env.llmConfigs | toJson | quote }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            # ConfigMap volume mount
+            - name: tenant-resources 
+              mountPath: /app/tenants #TODO: Discuss & test in docker compose
+              readOnly: true
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+        # ConfigMap volume
+        - name: tenant-resources
+          configMap:
+            name: {{ include "canso-fraud-analyst-service.fullname" . }}-cm
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/canso-data-plane/canso-fraud-analyst-service/templates/deployment.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/templates/deployment.yaml
@@ -46,10 +46,13 @@ spec:
             - name: CANSO_INVESTIGATIONS_USER
               value: {{ .Values.env.db.cansoInvestigations.user | quote }}
             - name: CANSO_INVESTIGATIONS_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: db-secrets #FIXME: Incorrect
-                  key: postgres-password #FIXME: Incorrect
+              value: {{ .Values.env.db.cansoInvestigations.password | quote }}
+              # The above is a temporary workaround. Postgres password is available
+              # in the Postgres component release & namespace
+              # valueFrom:
+              #   secretKeyRef:
+              #     name: db-secrets #FIXME: Incorrect
+              #     key: postgres-password #FIXME: Incorrect
             - name: CANSO_VECTOR_DB_HOST
               value: {{ .Values.env.vectorDB.cansoCommon.host | quote }}
             - name: CANSO_VECTOR_DB_PORT
@@ -57,10 +60,13 @@ spec:
             - name: CANSO_VECTOR_DB_USER
               value: {{ .Values.env.vectorDB.cansoCommon.user | quote }}
             - name: CANSO_VECTOR_DB_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: db-secrets #FIXME: Incorrect
-                  key: milvus-password #FIXME: Incorrect
+              value: {{ .Values.env.vectorDB.cansoCommon.password | quote }}
+              # The above is a temporary workaround. Milvus Password is available
+              # in the Milvus component release & namespace.
+              # valueFrom:
+              #   secretKeyRef:
+              #     name: db-secrets #FIXME: Incorrect
+              #     key: milvus-password #FIXME: Incorrect
             - name: CANSO_LLM_CONFIGS
               value: {{ .Values.env.llmConfigs | toJson | quote }}
             - name: TENANT_CONFIG_ROOT_PATH

--- a/canso-data-plane/canso-fraud-analyst-service/templates/hpa.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "canso-fraud-analyst-service.fullname" . }}
+  labels:
+    {{- include "canso-fraud-analyst-service.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "canso-fraud-analyst-service.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/canso-data-plane/canso-fraud-analyst-service/templates/ingress.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "canso-fraud-analyst-service.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "canso-fraud-analyst-service.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/canso-data-plane/canso-fraud-analyst-service/templates/service.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "canso-fraud-analyst-service.fullname" . }}
+  labels:
+    {{- include "canso-fraud-analyst-service.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "canso-fraud-analyst-service.selectorLabels" . | nindent 4 }}

--- a/canso-data-plane/canso-fraud-analyst-service/templates/serviceaccount.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "canso-fraud-analyst-service.serviceAccountName" . }}
+  labels:
+    {{- include "canso-fraud-analyst-service.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/canso-data-plane/canso-fraud-analyst-service/templates/tests/test-connection.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "canso-fraud-analyst-service.fullname" . }}-test-connection"
+  labels:
+    {{- include "canso-fraud-analyst-service.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "canso-fraud-analyst-service.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/canso-data-plane/canso-fraud-analyst-service/values.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/values.yaml
@@ -94,17 +94,13 @@ ingress:
 
 ## @param resources Resource Configuration
 ##
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  limits:
+    cpu: 400m
+    memory: 384Mi
+  requests:
+    cpu: 750m
+    memory: 768Mi
 
 ## @section Liveness Probe Configurations
 ## @param livenessProbe.enabled Specifies if the liveness probe is enabled

--- a/canso-data-plane/canso-fraud-analyst-service/values.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/values.yaml
@@ -1,0 +1,243 @@
+# Default values for canso-fraud-analyst-service.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+## @skip replicaCount Number of replicas
+replicaCount: 1
+
+## @section Image Configuration
+image:
+  ## @param image.repository repository for the image
+  ##
+  repository: ""
+  ## @param image.pullPolicy Pull policy for the image
+  ##
+  pullPolicy: Always
+  ## @param image.tag Tag for the image
+  ##
+  tag: ""
+
+## @param imagePullSecrets Image pull secrets
+##
+imagePullSecrets: []
+## @skip nameOverride Name override
+nameOverride: ""
+## @skip fullnameOverride Full name override
+fullnameOverride: ""
+
+## @section serviceAccount Image pull secrets
+## 
+serviceAccount:
+  ## @param serviceAccount.create Specifies whether a service account should be created
+  ##
+  create: true
+  ## @param serviceAccount.automount Automatically mount a ServiceAccount's API credentials?
+  ##
+  automount: true
+  ## @param serviceAccount.annotations Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  ## @param serviceAccount.name SA Name
+  ##
+  name: ""
+
+## @param podAnnotations POD Annotations
+##
+podAnnotations: {}
+## @param podLabels POD Labels
+##
+podLabels: {}
+
+## @param podSecurityContext POD Security Context
+##
+podSecurityContext: {}
+  # fsGroup: 2000
+
+## @param securityContext Security Context
+##
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+## @section service Service Configuration
+##
+service:
+  ## @param service.type Service Type (ClusterIP, NodePort, and LoadBalancer)
+  ##
+  type: ClusterIP
+  ## @param service.port Port used by clients to access the service
+  ##
+  port: 80
+
+## @skip ingress Ingress Configuration
+##
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+## @param resources Resource Configuration
+##
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+## @section Liveness Probe Configurations
+## @param livenessProbe.enabled Specifies if the liveness probe is enabled
+##
+livenessProbe:
+  ## @param livenessProbe.enabled Specifies if the liveness probe is enabled
+  ##
+  enabled: true
+  ## @param livenessProbe.initialDelaySeconds Number of seconds after the container has started before liveness probes are initiated
+  ##
+  initialDelaySeconds: 60
+  ## @param livenessProbe.periodSeconds How often to perform the probe
+  ##
+  periodSeconds: 10
+  ## @param livenessProbe.timeoutSeconds Number of seconds after which the probe times out
+  ##
+  timeoutSeconds: 20
+  ## @param livenessProbe.successThreshold Success threshold for liveness probe
+  ##
+  successThreshold: 1
+  ## @param livenessProbe.failureThreshold Minimum consecutive failures for the probe to be considered failed
+  ##
+  failureThreshold: 3
+  ## @param livenessProbe.path  The path for the liveness probe
+  ##
+  path: /health
+  ## @param livenessProbe.port  The port to use for the probe
+  ##
+  port: http
+
+## @section Readiness Probe Configurations
+readinessProbe:
+  ## @param readinessProbe.enabled  Specifies if the readiness probe is enabled
+  ##
+  enabled: true
+  ## @param readinessProbe.initialDelaySeconds  Number of seconds after the container has started before readiness probes are initiated
+  ##
+  initialDelaySeconds: 30
+  ## @param readinessProbe.periodSeconds  How often to perform the probe
+  ##
+  periodSeconds: 10
+  ## @param readinessProbe.timeoutSeconds  Number of seconds after which the probe times out
+  ##
+  timeoutSeconds: 20
+  ## @param readinessProbe.successThreshold Success threshold for readiness probe
+  ##
+  successThreshold: 1
+  ## @param readinessProbe.failureThreshold  Minimum consecutive failures for the probe to be considered failed
+  ##
+  failureThreshold: 6
+  ## @param readinessProbe.path  The path for the readiness probe
+  ##
+  path: /health
+  ## @param readinessProbe.port  The port to use for the probe
+  ##
+  port: http
+
+autoscaling:
+  ## @param autoscaling.enabled Enable autoscaling
+  ##
+  enabled: true
+  ## @param autoscaling.minReplicas Minimum number of replicas
+  ##
+  minReplicas: 1
+  ## @param autoscaling.maxReplicas Minimum number of replicas
+  ##
+  maxReplicas: 3
+  ## @param autoscaling.targetCPUUtilizationPercentage Target CPU utilization percentage
+  ##
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+
+## @param volumes Additional volumes on the output Deployment definition.
+##
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+
+## @param volumeMounts Additional volumeMounts on the output Deployment definition.
+##
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+## @param nodeSelector to select for scheduling of pod on a node
+##
+nodeSelector: {}
+
+## @param tolerations Taints that pod can tolerate
+##  
+tolerations: []
+  # - key: "key"
+  #   operator: "Equal"
+  #   value: "value"
+  #   effect: "NoSchedule"
+
+## @param affinity Affinity rules for pod scheduling on a node
+##  
+affinity: {}
+  # nodeAffinity:
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #     nodeSelectorTerms:
+  #     - matchExpressions:
+  #       - key: kubernetes.io/e2e-az-name
+  #         operator: In
+  #         values:
+  #         - e2e-az1
+  #         - e2e-az2
+
+## @skip env Canso internal Environment Variables
+env:
+  db:
+    cansoInvestigations:
+      host: ""
+      port: 5432
+      database: ""
+      user: "postgres"
+      password: ""
+  vectorDB:
+    cansoCommon:
+      host: ""
+      port: 19530
+      user: ""
+      password: ""
+  llmConfigs: {}
+
+## @skip configMaps Configuration Maps for Tenant Specific Extract & Transform operations
+configMaps:
+  fraudAnalyst:
+    tenantDataETConnConfigs: {}
+    tenantDataETConfigs: {}


### PR DESCRIPTION
## Summary

- Helm create for scaffolding
- Documentation for readme generator CI
- Deployment YAML & Values updated to support expected env variables
- Configmaps added & corresponding volume & volume mount in deployment updated. Values YAML don't have default values.

## Tests

```console
(base) ➜  canso-fraud-analyst-service git:(canso-fraud-analyst-svc-helm) ✗ helm lint
==> Linting .
[INFO] Chart.yaml: icon is recommended

1 chart(s) linted, 0 chart(s) failed
```

## TODOs

- [ ] See FIXME or TODO comments in the files changed.