### PR TITLE
BugFix - Canso DB Migrations - Delete older Chart Lock

### DIFF
--- a/canso-data-plane/canso-investigations-db/Chart.lock
+++ b/canso-data-plane/canso-investigations-db/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 16.6.1
-digest: sha256:6860ad8c992a6450249e33b76ef259b653c8eaf9641a2da165770eeece637530
-generated: "2025-04-24T21:36:10.138165+05:30"


### PR DESCRIPTION
Remove chart lock. This is not needed and was the root cause behind the failed github action run [here](https://github.com/Yugen-ai/canso-helm-charts/actions/runs/14733554742)