### PR TITLE
[NOJIRA] Remove enabled flag inside livenessProbe and readinessProbe for deplo…

### DIFF
--- a/canso-data-plane/canso-fraud-analyst-service/Chart.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-fraud-analyst-service/templates/deployment.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/templates/deployment.yaml
@@ -80,9 +80,27 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- if .Values.livenessProbe.enabled }}
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.livenessProbe.port }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            {{- end }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- if .Values.readinessProbe.enabled }}
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.readinessProbe.port }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION

### Description
Remove the enabled flag inside the livenessProbe and readinessProbe for deployment. Kubernetes doesn't recognise `enabled` as a valid property of livenessProbe, and `path`/`port` need to be nested under an HTTP handler like httpGet.

### Testing 
<details><summary> Helm templated Res: </summary>
<p>

```yaml
# Source: canso-fraud-analyst-service/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: release-name-canso-fraud-analyst-service
  labels:
    helm.sh/chart: canso-fraud-analyst-service-0.1.0
    app.kubernetes.io/name: canso-fraud-analyst-service
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "core-v0.0.1rc1-python-3.13-slim"
    app.kubernetes.io/managed-by: Helm
spec:
  selector:
    matchLabels:
      app.kubernetes.io/name: canso-fraud-analyst-service
      app.kubernetes.io/instance: release-name
  template:
    metadata:
      labels:
        helm.sh/chart: canso-fraud-analyst-service-0.1.0
        app.kubernetes.io/name: canso-fraud-analyst-service
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "core-v0.0.1rc1-python-3.13-slim"
        app.kubernetes.io/managed-by: Helm
    spec:
      serviceAccountName: release-name-canso-fraud-analyst-service
      securityContext:
        {}
      containers:
        - name: canso-fraud-analyst-service
          securityContext:
            {}
          image: ":core-v0.0.1rc1-python-3.13-slim"
          imagePullPolicy: Always
          env:
            - name: CANSO_INVESTIGATIONS_HOST
              value: ""
            - name: CANSO_INVESTIGATIONS_PORT
              value: "5432"
            - name: CANSO_INVESTIGATIONS_DATABASE
              value: ""
            - name: CANSO_INVESTIGATIONS_USER
              value: "postgres"
            - name: CANSO_INVESTIGATIONS_PASSWORD
              value: ""
              # The above is a temporary workaround. Postgres password is available
              # in the Postgres component release & namespace
              # valueFrom:
              #   secretKeyRef:
              #     name: db-secrets #FIXME: Incorrect
              #     key: postgres-password #FIXME: Incorrect
            - name: CANSO_VECTOR_DB_HOST
              value: ""
            - name: CANSO_VECTOR_DB_PORT
              value: "19530"
            - name: CANSO_VECTOR_DB_USER
              value: ""
            - name: CANSO_VECTOR_DB_PASSWORD
              value: ""
              # The above is a temporary workaround. Milvus Password is available
              # in the Milvus component release & namespace.
              # valueFrom:
              #   secretKeyRef:
              #     name: db-secrets #FIXME: Incorrect
              #     key: milvus-password #FIXME: Incorrect
            - name: CANSO_LLM_CONFIGS
              value: "{}"
            - name: TENANT_CONFIG_ROOT_PATH
              value: "/opt/canso-fraud-analyst-service/app/tenants"
            - name: TENANT_DATA_ET_CONN_CONFIG_PATH
              value: "/opt/canso-fraud-analyst-service/app/tenants/data_et_conn_configs.json"
            - name: TENANT_DATA_ET_CONFIG_PATH
              value: "/opt/canso-fraud-analyst-service/app/tenants/data_et_configs.json"
          ports:
            - name: http
              containerPort: 80
              protocol: TCP
          livenessProbe:
            httpGet:
              path: /health
              port: http
            initialDelaySeconds: 60
            periodSeconds: 10
            timeoutSeconds: 20
            successThreshold: 1
            failureThreshold: 3
          readinessProbe:
            httpGet:
              path: /health
              port: http
            initialDelaySeconds: 30
            periodSeconds: 10
            timeoutSeconds: 20
            successThreshold: 1
            failureThreshold: 6
          resources:
            limits:
              cpu: 400m
              memory: 384Mi
            requests:
              cpu: 750m
              memory: 768Mi
          volumeMounts:
            # ConfigMap volume mount
            - name: tenant-resources 
              mountPath: /opt/canso-fraud-analyst-service/app/tenants #TODO: Discuss & test in docker compose
              readOnly: true
      volumes:
        # ConfigMap volume
        - name: tenant-resources
          configMap:
            name: release-name-canso-fraud-analyst-service-cm
```
</p>
</details>
