### PR TITLE
Canso Fraud Analyst Service - Fix Requests<=Limits

### DIFF
--- a/canso-data-plane/canso-fraud-analyst-service/Chart.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-fraud-analyst-service/values.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/values.yaml
@@ -95,13 +95,13 @@ ingress:
 ## @param resources Resource Configuration
 ##
 resources:
-  limits:
+  requests:
     cpu: 400m
     memory: 384Mi
-  requests:
+  limits:
     cpu: 750m
     memory: 768Mi
-
+  
 ## @section Liveness Probe Configurations
 ## @param livenessProbe.enabled Specifies if the liveness probe is enabled
 ##


### PR DESCRIPTION
Fixes the following error. Requests & Limits values were interchanged.

```sh
one or more objects failed to apply, reason: Deployment.apps
      "fraud-analyst-service-canso-fraud-analyst-service" is invalid:
      [spec.template.spec.containers[0].resources.requests: Invalid value:
      "750m": must be less than or equal to cpu limit of 400m,
      spec.template.spec.containers[0].resources.requests: Invalid value:
      "768Mi": must be less than or equal to memory limit of 384Mi].
```

cc @Yugen-ai/platform-engineering 