### PR TITLE
Flexible env variables for the Canso Fraud Analyst

### DIFF
--- a/canso-data-plane/canso-fraud-analyst-service/Chart.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.2
+version: 0.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-fraud-analyst-service/templates/deployment.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/templates/deployment.yaml
@@ -41,6 +41,12 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+            - name: TENANT_CONFIG_ROOT_PATH
+              value: "/opt/canso-fraud-analyst-service/app/tenants"
+            - name: TENANT_DATA_ET_CONN_CONFIG_PATH
+              value: "/opt/canso-fraud-analyst-service/app/tenants/data_et_conn_configs.json"
+            - name: TENANT_DATA_ET_CONFIG_PATH
+              value: "/opt/canso-fraud-analyst-service/app/tenants/data_et_configs.json"
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/canso-data-plane/canso-fraud-analyst-service/templates/deployment.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/templates/deployment.yaml
@@ -37,44 +37,10 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
-            - name: CANSO_INVESTIGATIONS_HOST
-              value: {{ .Values.env.db.cansoInvestigations.host | quote }}
-            - name: CANSO_INVESTIGATIONS_PORT
-              value: {{ .Values.env.db.cansoInvestigations.port | quote }}
-            - name: CANSO_INVESTIGATIONS_DATABASE
-              value: {{ .Values.env.db.cansoInvestigations.database | quote }}
-            - name: CANSO_INVESTIGATIONS_USER
-              value: {{ .Values.env.db.cansoInvestigations.user | quote }}
-            - name: CANSO_INVESTIGATIONS_PASSWORD
-              value: {{ .Values.env.db.cansoInvestigations.password | quote }}
-              # The above is a temporary workaround. Postgres password is available
-              # in the Postgres component release & namespace
-              # valueFrom:
-              #   secretKeyRef:
-              #     name: db-secrets #FIXME: Incorrect
-              #     key: postgres-password #FIXME: Incorrect
-            - name: CANSO_VECTOR_DB_HOST
-              value: {{ .Values.env.vectorDB.cansoCommon.host | quote }}
-            - name: CANSO_VECTOR_DB_PORT
-              value: {{ .Values.env.vectorDB.cansoCommon.port | quote }}
-            - name: CANSO_VECTOR_DB_USER
-              value: {{ .Values.env.vectorDB.cansoCommon.user | quote }}
-            - name: CANSO_VECTOR_DB_PASSWORD
-              value: {{ .Values.env.vectorDB.cansoCommon.password | quote }}
-              # The above is a temporary workaround. Milvus Password is available
-              # in the Milvus component release & namespace.
-              # valueFrom:
-              #   secretKeyRef:
-              #     name: db-secrets #FIXME: Incorrect
-              #     key: milvus-password #FIXME: Incorrect
-            - name: CANSO_LLM_CONFIGS
-              value: {{ .Values.env.llmConfigs | toJson | quote }}
-            - name: TENANT_CONFIG_ROOT_PATH
-              value: "/opt/canso-fraud-analyst-service/app/tenants"
-            - name: TENANT_DATA_ET_CONN_CONFIG_PATH
-              value: "/opt/canso-fraud-analyst-service/app/tenants/data_et_conn_configs.json"
-            - name: TENANT_DATA_ET_CONFIG_PATH
-              value: "/opt/canso-fraud-analyst-service/app/tenants/data_et_configs.json"
+            {{- range $key, $value := .Values.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/canso-data-plane/canso-fraud-analyst-service/values.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/values.yaml
@@ -215,22 +215,6 @@ affinity: {}
   #         - e2e-az1
   #         - e2e-az2
 
-## @skip env Canso internal Environment Variables
-env:
-  db:
-    cansoInvestigations:
-      host: ""
-      port: 5432
-      database: ""
-      user: "postgres"
-      password: ""
-  vectorDB:
-    cansoCommon:
-      host: ""
-      port: 19530
-      user: ""
-      password: ""
-  llmConfigs: {}
 
 ## @skip configMaps Configuration Maps for Tenant Specific Extract & Transform operations
 configMaps:


### PR DESCRIPTION
## Description

Addresses feedback & TODO discussed [here](https://github.com/Yugen-ai/canso-helm-charts/pull/89#discussion_r2065791530).

Additionally, this will help address the issue where the expected env variable is incorrectly set to `CANSO_INVESTIGATIONS_DATABASE`, but should be `CANSO_INVESTIGATIONS_DB`

cc @Yugen-ai/platform-engineering 