### PR TITLE
Improved version of the Canso Investigations DB Helm chart

### DIFF
--- a/canso-data-plane/canso-investigations-db/Chart.yaml
+++ b/canso-data-plane/canso-investigations-db/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-investigations-db/templates/_helpers.tpl
+++ b/canso-data-plane/canso-investigations-db/templates/_helpers.tpl
@@ -65,6 +65,7 @@ Create the name of the service account to use
 {{/* 
 Generate PostgreSQL JDBC connection URL
 */}}
+# Format - `jdbc:postgresql://<postgres-service-name>.<namespace>.svc.cluster.local:<port>/<database>``
 {{- define "postgresql.jdbcUrl" -}}
-jdbc:postgresql://{{ printf "%s-postgresql-primary" .Release.Name }}.{{ .Release.Namespace }}.svc.cluster.local:5432/{{ .Values.postgresql.auth.database }}
+jdbc:postgresql://{{ .Values.env.postgresInit.PG_HOST }}.{{ .Values.env.postgresInit.PG_NAMESPACE }}.svc.cluster.local:{{ .Values.env.postgresInit.PG_PORT }}/{{ .Values.env.postgresInit.PG_DB }}
 {{- end -}}

--- a/canso-data-plane/canso-investigations-db/templates/job-db-migrations.yaml
+++ b/canso-data-plane/canso-investigations-db/templates/job-db-migrations.yaml
@@ -33,16 +33,14 @@ spec:
       - name: wait-for-db
         image: "postgres:16"
         imagePullPolicy: IfNotPresent
+        env:
+          {{- range $key, $value := .Values.env.postgresInit }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
         command: ['sh', '-c']
         args:
           - |
-            sleep 5
-
-            PG_HOST="{{ printf "%s-postgresql-primary" .Release.Name }}"
-            PG_PORT="5432"
-            PG_USER="{{ .Values.postgresql.auth.username }}"
-            PG_DB="{{ .Values.postgresql.auth.database }}"
-
             echo "Waiting for PostgreSQL primary service '$PG_HOST' to be ready..."
 
             until pg_isready -h "$PG_HOST" -p "$PG_PORT" -U "$PG_USER" -d "$PG_DB" -t 5; do
@@ -51,15 +49,6 @@ spec:
             done
 
             echo "PostgreSQL is ready! Proceeding with migrations."
-        env:
-          - name: PGPASSWORD
-            valueFrom:
-              secretKeyRef:
-                # Name of the secret created by the Bitnami PostgreSQL chart
-                # This usually follows the pattern '<RELEASE_NAME>-postgresql'
-                name: {{ printf "%s-postgresql" .Release.Name }}
-                # Key within the secret containing the PostgreSQL password
-                key: password
         resources:
           requests:
             memory: "64Mi"
@@ -81,22 +70,10 @@ spec:
           # Format: jdbc:postgresql://<service-name>.<namespace>.svc.cluster.local:<port>/<database>
           - name: FLYWAY_URL
             value: "{{ include "postgresql.jdbcUrl" . }}"
-          # Database username configured in the Bitnami subchart
-          - name: FLYWAY_USER
-            value: {{ .Values.postgresql.auth.username | quote }}
-          # Database password retrieved from the secret managed by the Bitnami subchart
-          - name: FLYWAY_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                # Name of the secret created by the Bitnami PostgreSQL chart
-                name: {{ printf "%s-postgresql" .Release.Name }}
-                # Key within the secret containing the PostgreSQL password
-                key: password
-          - name: FLYWAY_LOCATIONS
-            value: {{ .Values.dbSchemaSetup.flyway.locations | quote }}
-          - name: FLYWAY_SCHEMAS
-            value: {{ .Values.dbSchemaSetup.flyway.schemas | quote }}
+          {{- range $key, $value := .Values.env.flyway }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
         resources:
           {{- toYaml .Values.dbSchemaSetup.resources | nindent 10 }}
-
 {{- end }}

--- a/canso-data-plane/canso-investigations-db/values.yaml
+++ b/canso-data-plane/canso-investigations-db/values.yaml
@@ -2,7 +2,7 @@
 ####    Job Details for DB Migrations/Init
 ##############################################################################################
 
-## @section Job Details for DB Migrations
+## @section dbSchemaSetup Job Details for DB Migrations
 dbSchemaSetup:
    ## @param dbSchemaSetup.enabled Enable DB schema setup job
    ##
@@ -20,15 +20,6 @@ dbSchemaSetup:
   ## @param dbSchemaSetup.imagePullSecrets Image pull secrets for the Flyway migration job
   imagePullSecrets: []
   
-  ## @section dbSchemaSetup.flyway Flyway configurations
-  ##
-  flyway:
-    ## @param dbSchemaSetup.flyway.locations Flyway directory containing SQL migration scripts  
-    locations: "filesystem:/flyway/sql"
-    ## @param dbSchemaSetup.flyway.schemas Flyway schemas to be used
-    ##
-    schemas: ""
-
   ## @param dbSchemaSetup.backoffLimit Job backoff limit
   ##
   backoffLimit: 2
@@ -50,10 +41,28 @@ dbSchemaSetup:
   ##
   resources:
     requests:
-      memory: "64Mi"
-      cpu: "100m"
+      memory: "768Mi" # Warning - DO NOT REDUCE. Java Heap needs 300MB at-least, flyway image size ~256MB.
+      cpu: "250m"
     limits:
-      memory: "128Mi"
-      cpu: "200m"
-  
+      memory: "1Gi"
+      cpu: "750m"
 
+
+## @skip env Environment variables
+env:
+  postgresInit:
+    # These are used by `pg_isready` to check connection status of a PostgreSQL server
+    # as part of the init container.
+    PG_HOST: ""  # Postgres Service. Format is usually: "<postgres-release>-postgresql-primary"
+    PG_PORT: "5432"
+    PG_USER: ""
+    PG_DB: ""
+    PG_NAMESPACE: "canso-ai-agents"
+  flyway:
+    FLYWAY_USER: "" # Currently same as `env.postgresInit.PG_USER`
+    FLYWAY_PASSWORD: "" # Same as password`used while deploying the Postgres component
+    # Flyway locations - https://documentation.red-gate.com/fd/flyway-locations-setting-277579008.html
+    # See https://github.com/Yugen-ai/canso-fraud-analyst-service/blob/main/Dockerfile.DBMigrations
+    FLYWAY_LOCATIONS: "filesystem:/flyway/sql"
+    # Flyway schemas to be used
+    FLYWAY_SCHEMAS: "events"


### PR DESCRIPTION
## Summary

- Finalise Environment variables (Init container + Flyway)
- Init Container now references postgres via env variables (this is a prior component deploy step in our system)
- Flyway configs moved to env variables as well
- Update `postgresql.jdbcUrl` to use env variables
- Appropriate Requests & Limits for the Flyway POD (Warning on JVM added)
- Tests done on a local minkube cluster

## Tests

### Helm Install

```sh
(base) ➜  canso-investigations-db git:(flyway-migration-fixes) ✗ helm install db-migration . \
 --set dbSchemaSetup.image.repository="shaktimaanbot/canso-fraud-analyst-service" \
 --set dbSchemaSetup.image.tag="db-v0.1.0-flyway-11.8-alpine" \
 --set dbSchemaSetup.enabled=true \
 --set env.postgresInit.PG_HOST="canso-db-postgresql-primary" \
 --set env.postgresInit.PG_USER="postgres" \
 --set env.postgresInit.PG_DB="cansocasesdb" \
 --set env.postgresInit.PG_NAMESPACE="canso-fraud-storage" \
 --set env.flyway.FLYWAY_USER="postgres" \
 --set env.flyway.FLYWAY_PASSWORD="...<redacted>..." \
 -n canso-fraud-storage \
 --create-namespace
NAME: db-migration
LAST DEPLOYED: Thu May  1 10:46:03 2025
NAMESPACE: canso-fraud-storage
STATUS: deployed
REVISION: 1
TEST SUITE: None
```

FYI @ashishYugen 

cc @Yugen-ai/platform-engineering 



### Connect to Postgres DB

```sh
(base) ➜  canso-investigations-db git:(flyway-migration-fixes) ✗ kubectl exec -it canso-db-postgresql-primary-0 -n canso-fraud-storage -- bash
I have no name!@canso-db-postgresql-primary-0:/$ psql -U postgres
Password for user postgres:
```

### See all DBs

```sh
postgres=> \l
                                                        List of databases
     Name     |   Owner   | Encoding | Locale Provider |   Collate   |    Ctype    | Locale | ICU Rules |    Access privileges
--------------+-----------+----------+-----------------+-------------+-------------+--------+-----------+-------------------------
 cansocasesdb | cansouser | UTF8     | libc            | en_US.UTF-8 | en_US.UTF-8 |        |           | =Tc/cansouser          +
              |           |          |                 |             |             |        |           | cansouser=CTc/cansouser
 postgres     | postgres  | UTF8     | libc            | en_US.UTF-8 | en_US.UTF-8 |        |           |
 template0    | postgres  | UTF8     | libc            | en_US.UTF-8 | en_US.UTF-8 |        |           | =c/postgres            +
              |           |          |                 |             |             |        |           | postgres=CTc/postgres
 template1    | postgres  | UTF8     | libc            | en_US.UTF-8 | en_US.UTF-8 |        |           | =c/postgres            +
              |           |          |                 |             |             |        |           | postgres=CTc/postgres
(4 rows)
```

### List Tables in schema

```sh
cansocasesdb=# \dt events.*;
                      List of relations
 Schema |              Name               | Type  |  Owner
--------+---------------------------------+-------+----------
 events | canso_case_interviews           | table | postgres
 events | canso_case_notes                | table | postgres
 events | canso_case_observations         | table | postgres
 events | canso_case_recommendations      | table | postgres
 events | canso_case_verification_details | table | postgres
 events | canso_post_disbursal_cases      | table | postgres
 events | flyway_schema_history           | table | postgres
(7 rows)
```