### PR TITLE
Canso Investigations DB - Remove Hooks to make DB Migrations Job run independently

### DIFF
--- a/canso-data-plane/canso-investigations-db/Chart.yaml
+++ b/canso-data-plane/canso-investigations-db/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-investigations-db/templates/job-db-migrations.yaml
+++ b/canso-data-plane/canso-investigations-db/templates/job-db-migrations.yaml
@@ -11,10 +11,6 @@ metadata:
   labels:
     {{- include "canso-investigations-db.labels" . | nindent 4 }}
     app.kubernetes.io/component: db-schema-migration
-  annotations:
-    helm.sh/hook: pre-install,pre-upgrade
-    helm.sh/hook-weight: "-5"
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 spec:
   backoffLimit: {{ .Values.dbSchemaSetup.backoffLimit }}
   ttlSecondsAfterFinished: {{ .Values.dbSchemaSetup.ttlSecondsAfterFinished }}


### PR DESCRIPTION
We noticed that the ArgoCD application gets created in the data plane and is synced + healthy, but the DB migration job isn't created. This PR will likely solve this issue.

cc @ashishYugen 