### PR TITLE
Canso Investigations DB - `secretKeyRef` doesn't support cross-namespace references

### DIFF
--- a/canso-data-plane/canso-investigations-db/Chart.yaml
+++ b/canso-data-plane/canso-investigations-db/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-investigations-db/templates/job-db-migrations.yaml
+++ b/canso-data-plane/canso-investigations-db/templates/job-db-migrations.yaml
@@ -75,7 +75,6 @@ spec:
               secretKeyRef:
                 name: {{ .Values.flyway.db_secret_name }}
                 key: {{ .Values.flyway.db_secret_password_key }}
-                namespace: {{ .Values.db_namespace }}
         resources:
           {{- toYaml .Values.dbSchemaSetup.resources | nindent 10 }}
 {{- end }}


### PR DESCRIPTION
While running the DB migrations job in the data plane, we came across the following error -

```sh
.spec.template.spec.containers[name="flyway-migrate"].env[name="FLYWAY_P │
│ ASSWORD"].valueFrom.secretKeyRef.namespace: field not declared in schema (retried 5 times).
```

`namespace` is not a valid input inside `secretKeyRef`. This PR fixes that.