### PR TITLE
Support both image tags & SHAs in Canso Investigations DB

### DIFF
--- a/canso-data-plane/canso-investigations-db/Chart.yaml
+++ b/canso-data-plane/canso-investigations-db/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-investigations-db/Chart.yaml
+++ b/canso-data-plane/canso-investigations-db/Chart.yaml
@@ -21,4 +21,4 @@ version: 0.1.5
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.16.0"
+appVersion: "db-v0.1.1-flyway-11.8-alpine"

--- a/canso-data-plane/canso-investigations-db/templates/_helpers.tpl
+++ b/canso-data-plane/canso-investigations-db/templates/_helpers.tpl
@@ -60,3 +60,17 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+
+{{/*
+Create the image path for the passed in image field
+Credits - https://blog.andyserver.com/2021/09/adding-image-digest-references-to-your-helm-charts/
+*/}}
+{{- define "canso-investigations-db.image" -}}
+{{- $tag := .tag -}}
+{{- if eq (substr 0 7 $tag) "sha256:" -}}
+{{- printf "%s@%s" .repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" .repository $tag -}}
+{{- end -}}
+{{- end -}}

--- a/canso-data-plane/canso-investigations-db/templates/job-db-migrations.yaml
+++ b/canso-data-plane/canso-investigations-db/templates/job-db-migrations.yaml
@@ -59,7 +59,7 @@ spec:
 
       containers:
       - name: flyway-migrate
-        image: "{{ .Values.dbSchemaSetup.image.repository }}:{{ .Values.dbSchemaSetup.image.tag }}"
+        image: {{ include "canso-investigations-db.image" (dict "repository" .Values.dbSchemaSetup.image.repository "tag" (default .Chart.AppVersion .Values.dbSchemaSetup.image.tag)) }}
         imagePullPolicy: {{ .Values.dbSchemaSetup.image.pullPolicy }}
         command: ["flyway"]
         args:


### PR DESCRIPTION
### Description

Had created the helm chart using the `helm create` template and had forgotten to add the helper that supports image tags/SHAs in deployment - this is something we have followed in most of our charts.



cc @Yugen-ai/platform-engineering 