### PR TITLE
[NOJIRA] Fix Correct aws secret name for Dockerhub cred

### DIFF
--- a/canso-data-plane/canso-fraud-analyst-service/Chart.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.5
+version: 0.1.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/canso-data-plane/canso-fraud-analyst-service/values.yaml
+++ b/canso-data-plane/canso-fraud-analyst-service/values.yaml
@@ -188,7 +188,7 @@ external_secret:
   ## @param external_secret.target_secret_name_key Target secret name key.
   target_secret_name_key: .dockerconfigjson
   ## @param external_secret.aws_secret_name secret name.
-  aws_secret_name: canso/dockerhub
+  aws_secret_name: canso-dockerhub-credentials
   ## @param external_secret.aws_secret_key secret key.
   aws_secret_key: dockerhub
 


### PR DESCRIPTION

### Description
Update the correct AWS secret name for Docker Hub credentials.

### Testing

<details><summary> helm template . -f values.yaml > template.txt </summary>
<p>

```yaml
---
# Source: canso-fraud-analyst-service/templates/external-secrets.yaml
apiVersion: external-secrets.io/v1beta1
kind: ExternalSecret
metadata:
  name: canso-dockerhub-credentials-es
  namespace: default
spec:
  refreshInterval: 1m
  secretStoreRef:
    name: secretstore-by-role
    kind: ClusterSecretStore
  target:
    name: canso-dockerhub-credentials
    creationPolicy: Owner
    template:
      type: kubernetes.io/dockerconfigjson
  data:
  - secretKey: .dockerconfigjson
    remoteRef:
      key: canso-dockerhub-credentials
      property: dockerhub
---
```

</p>
</details>

### Deployment 
1. Standard PR merge and automatically release the new version of the helm chart
2. Deploy fraud analyst services with the new chart version.

### Rollback
1. Standard PR revert.
2. Delete the new release chart version in gh-pages.
