### PR TITLE
Add Helm chart for canso data plane agent

### DIFF
--- a/canso-data-plane/canso-dataplane-agent/.helmignore
+++ b/canso-data-plane/canso-dataplane-agent/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/canso-data-plane/canso-dataplane-agent/Chart.yaml
+++ b/canso-data-plane/canso-dataplane-agent/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: canso-dataplane-agent
+description: A Helm chart to deploy the canso data plane agent
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.0.1-python-3.13-slim"

--- a/canso-data-plane/canso-dataplane-agent/README.md
+++ b/canso-data-plane/canso-dataplane-agent/README.md
@@ -40,7 +40,6 @@
 | Name                                | Description                                                                            | Value            |
 | ----------------------------------- | -------------------------------------------------------------------------------------- | ---------------- |
 | `livenessProbe.enabled`             | Specifies if the liveness probe is enabled                                             | `true`           |
-| `livenessProbe.enabled`             | Specifies if the liveness probe is enabled                                             | `true`           |
 | `livenessProbe.initialDelaySeconds` | Number of seconds after the container has started before liveness probes are initiated | `30`             |
 | `livenessProbe.periodSeconds`       | How often to perform the probe                                                         | `10`             |
 | `livenessProbe.timeoutSeconds`      | Number of seconds after which the probe times out                                      | `20`             |
@@ -66,6 +65,23 @@
 | `autoscaling.maxReplicas`                       | Minimum number of replicas                                                              | `5`              |
 | `autoscaling.targetCPUUtilizationPercentage`    | Target CPU utilization percentage                                                       | `80`             |
 | `autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage                                                    | `90`             |
+
+### Ingress Configuration
+
+| Name                       | Description                   | Value    |
+| -------------------------- | ----------------------------- | -------- |
+| `ingress.enabled`          | Enable the ingress            | `false`  |
+| `ingress.host`             | Hostname for the ingress rule | `""`     |
+| `ingress.path`             | Path for path-based routing   | `/`      |
+| `ingress.pathType`         | Path type for the ingress     | `Prefix` |
+| `ingress.ingressClassName` | Ingress class name            | `alb`    |
+
+### Network Policy Configuration
+
+| Name                           | Description                                                     | Value        |
+| ------------------------------ | --------------------------------------------------------------- | ------------ |
+| `networkPolicy.enabled`        | Enable the network policy                                       | `false`      |
+| `networkPolicy.ingressVpcCidr` | VPC CIDR from which ALB sends traffic to pods (target-type: ip) | `10.0.0.0/8` |
 
 ### Image Pull secret configuration
 

--- a/canso-data-plane/canso-dataplane-agent/README.md
+++ b/canso-data-plane/canso-dataplane-agent/README.md
@@ -68,20 +68,21 @@
 
 ### Ingress Configuration
 
-| Name                       | Description                   | Value    |
-| -------------------------- | ----------------------------- | -------- |
-| `ingress.enabled`          | Enable the ingress            | `false`  |
-| `ingress.host`             | Hostname for the ingress rule | `""`     |
-| `ingress.path`             | Path for path-based routing   | `/`      |
-| `ingress.pathType`         | Path type for the ingress     | `Prefix` |
-| `ingress.ingressClassName` | Ingress class name            | `alb`    |
+| Name                        | Description                                                              | Value           |
+| --------------------------- | ------------------------------------------------------------------------ | --------------- |
+| `ingress.enabled`           | Enable the ingress                                                       | `false`         |
+| `ingress.host`              | Hostname for the ingress rule (must match the nginx master ingress host) | `""`            |
+| `ingress.path`              | Path exposed externally — routed to the service without rewriting        | `/api/v1/relay` |
+| `ingress.pathType`          | Path type for the ingress                                                | `Prefix`        |
+| `ingress.ingressClassName`  | Ingress class name                                                       | `nginx`         |
+| `ingress.clientMaxBodySize` | Maximum allowed request body size                                        | `100m`          |
 
 ### Network Policy Configuration
 
-| Name                           | Description                                                     | Value        |
-| ------------------------------ | --------------------------------------------------------------- | ------------ |
-| `networkPolicy.enabled`        | Enable the network policy                                       | `false`      |
-| `networkPolicy.ingressVpcCidr` | VPC CIDR from which ALB sends traffic to pods (target-type: ip) | `10.0.0.0/8` |
+| Name                                  | Description                                       | Value           |
+| ------------------------------------- | ------------------------------------------------- | --------------- |
+| `networkPolicy.enabled`               | Enable the network policy                         | `true`          |
+| `networkPolicy.nginxIngressNamespace` | Namespace where the nginx ingress controller runs | `nginx-ingress` |
 
 ### Image Pull secret configuration
 

--- a/canso-data-plane/canso-dataplane-agent/README.md
+++ b/canso-data-plane/canso-dataplane-agent/README.md
@@ -2,14 +2,14 @@
 
 ### deployment configuration
 
-| Name                          | Description                 | Value                                 |
-| ----------------------------- | --------------------------- | ------------------------------------- |
-| `deployment.image.repository` | repository for the image    | `shaktimaanbot/canso-dataplane-agent` |
-| `deployment.image.pullPolicy` | Pull policy for the image   | `Always`                              |
-| `deployment.image.tag`        | Tag for the image           | `python-3.13-slim-v0.0.1`             |
-| `deployment.replicas`         | replicas for the deployment | `1`                                   |
-| `podAnnotations`              | POD Annotations             | `{}`                                  |
-| `podLabels`                   | POD Labels                  | `{}`                                  |
+| Name                         | Description                            | Value                                                         |
+| ---------------------------- | -------------------------------------- | ------------------------------------------------------------- |
+| `deployment.image`           | Full image identifier (repository:tag) | `shaktimaanbot/canso-dataplane-agent:python-3.13-slim-v0.0.1` |
+| `deployment.imagePullPolicy` | Pull policy for the image              | `Always`                                                      |
+| `deployment.replicas`        | replicas for the deployment            | `1`                                                           |
+| `name`                       | Name of the service                    | `canso-dataplane-agent`                                       |
+| `podAnnotations`             | POD Annotations                        | `{}`                                                          |
+| `podLabels`                  | POD Labels                             | `{}`                                                          |
 
 ### service Service Configuration
 

--- a/canso-data-plane/canso-dataplane-agent/README.md
+++ b/canso-data-plane/canso-dataplane-agent/README.md
@@ -1,0 +1,74 @@
+## Parameters
+
+### deployment configuration
+
+| Name                         | Description                                               | Value    |
+| ---------------------------- | --------------------------------------------------------- | -------- |
+| `deployment.image`           | full image identifier                                     | `""`     |
+| `deployment.imagePullPolicy` | Image pull policy for the deployment                      | `Always` |
+| `deployment.replicas`        | Number of replicas for the canso-fraud-inv-job deployment | `1`      |
+
+### service Service Configuration
+
+| Name           | Description                                          | Value       |
+| -------------- | ---------------------------------------------------- | ----------- |
+| `service.type` | Service Type (ClusterIP, NodePort, and LoadBalancer) | `ClusterIP` |
+| `service.port` | Port used by clients to access the service           | `8000`      |
+
+### resources Resource Configuration
+
+
+### resources.request Resource request Configuration
+
+| Name                        | Description                           | Value   |
+| --------------------------- | ------------------------------------- | ------- |
+| `resources.requests.cpu`    | Resource request  cpu Configuration   | `400m`  |
+| `resources.requests.memory` | Resource request memory Configuration | `384Mi` |
+
+### resources.limits Resource limits Configuration
+
+| Name                      | Description                          | Value   |
+| ------------------------- | ------------------------------------ | ------- |
+| `resources.limits.cpu`    | Resource limits cpu Configuration    | `750m`  |
+| `resources.limits.memory` | Resource limits memory Configuration | `768Mi` |
+
+### Liveness Probe Configurations
+
+| Name                                | Description                                                                            | Value        |
+| ----------------------------------- | -------------------------------------------------------------------------------------- | ------------ |
+| `livenessProbe.enabled`             | Specifies if the liveness probe is enabled                                             | `true`       |
+| `livenessProbe.enabled`             | Specifies if the liveness probe is enabled                                             | `true`       |
+| `livenessProbe.initialDelaySeconds` | Number of seconds after the container has started before liveness probes are initiated | `30`         |
+| `livenessProbe.periodSeconds`       | How often to perform the probe                                                         | `10`         |
+| `livenessProbe.timeoutSeconds`      | Number of seconds after which the probe times out                                      | `20`         |
+| `livenessProbe.successThreshold`    | Success threshold for liveness probe                                                   | `1`          |
+| `livenessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed                     | `3`          |
+| `livenessProbe.path`                | The path for the liveness probe                                                        | `/v1/health` |
+| `livenessProbe.port`                | The port to use for the probe                                                          | `http`       |
+
+### Readiness Probe Configurations
+
+| Name                                            | Description                                                                             | Value        |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------- | ------------ |
+| `readinessProbe.enabled`                        | Specifies if the readiness probe is enabled                                             | `true`       |
+| `readinessProbe.initialDelaySeconds`            | Number of seconds after the container has started before readiness probes are initiated | `30`         |
+| `readinessProbe.periodSeconds`                  | How often to perform the probe                                                          | `10`         |
+| `readinessProbe.timeoutSeconds`                 | Number of seconds after which the probe times out                                       | `20`         |
+| `readinessProbe.successThreshold`               | Success threshold for readiness probe                                                   | `1`          |
+| `readinessProbe.failureThreshold`               | Minimum consecutive failures for the probe to be considered failed                      | `6`          |
+| `readinessProbe.path`                           | The path for the readiness probe                                                        | `/v1/health` |
+| `readinessProbe.port`                           | The port to use for the probe                                                           | `http`       |
+| `autoscaling.enabled`                           | Enable autoscaling                                                                      | `true`       |
+| `autoscaling.minReplicas`                       | Minimum number of replicas                                                              | `1`          |
+| `autoscaling.maxReplicas`                       | Minimum number of replicas                                                              | `5`          |
+| `autoscaling.targetCPUUtilizationPercentage`    | Target CPU utilization percentage                                                       | `80`         |
+| `autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage                                                    | `90`         |
+
+### Image Pull secret configuration
+
+| Name                                      | Description                                                   | Value                                  |
+| ----------------------------------------- | ------------------------------------------------------------- | -------------------------------------- |
+| `imagePullSecret.name`                    | Name of the Secret that will be created                       | `docker-secret-cred-tenant-et-service` |
+| `imagePullSecret.key`                     | Specific key inside the secret that will be created           | `.dockerconfigjson`                    |
+| `imagePullSecret.cloudProviderSecretName` | Name of the secret from the cloudprovider (AWS / GCP / AZURE) | `canso-dockerhub-credentials`          |
+| `imagePullSecret.cloudProviderSecretKey`  | Specific key inside the secret from cloud provider            | `dockerhub`                            |

--- a/canso-data-plane/canso-dataplane-agent/README.md
+++ b/canso-data-plane/canso-dataplane-agent/README.md
@@ -7,13 +7,15 @@
 | `deployment.image`           | full image identifier                                     | `""`     |
 | `deployment.imagePullPolicy` | Image pull policy for the deployment                      | `Always` |
 | `deployment.replicas`        | Number of replicas for the canso-fraud-inv-job deployment | `1`      |
+| `podAnnotations`             | POD Annotations                                           | `{}`     |
+| `podLabels`                  | POD Labels                                                | `{}`     |
 
 ### service Service Configuration
 
 | Name           | Description                                          | Value       |
 | -------------- | ---------------------------------------------------- | ----------- |
 | `service.type` | Service Type (ClusterIP, NodePort, and LoadBalancer) | `ClusterIP` |
-| `service.port` | Port used by clients to access the service           | `8000`      |
+| `service.port` | Port used by clients to access the service           | `8090`      |
 
 ### resources Resource Configuration
 
@@ -34,41 +36,41 @@
 
 ### Liveness Probe Configurations
 
-| Name                                | Description                                                                            | Value        |
-| ----------------------------------- | -------------------------------------------------------------------------------------- | ------------ |
-| `livenessProbe.enabled`             | Specifies if the liveness probe is enabled                                             | `true`       |
-| `livenessProbe.enabled`             | Specifies if the liveness probe is enabled                                             | `true`       |
-| `livenessProbe.initialDelaySeconds` | Number of seconds after the container has started before liveness probes are initiated | `30`         |
-| `livenessProbe.periodSeconds`       | How often to perform the probe                                                         | `10`         |
-| `livenessProbe.timeoutSeconds`      | Number of seconds after which the probe times out                                      | `20`         |
-| `livenessProbe.successThreshold`    | Success threshold for liveness probe                                                   | `1`          |
-| `livenessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed                     | `3`          |
-| `livenessProbe.path`                | The path for the liveness probe                                                        | `/v1/health` |
-| `livenessProbe.port`                | The port to use for the probe                                                          | `http`       |
+| Name                                | Description                                                                            | Value            |
+| ----------------------------------- | -------------------------------------------------------------------------------------- | ---------------- |
+| `livenessProbe.enabled`             | Specifies if the liveness probe is enabled                                             | `true`           |
+| `livenessProbe.enabled`             | Specifies if the liveness probe is enabled                                             | `true`           |
+| `livenessProbe.initialDelaySeconds` | Number of seconds after the container has started before liveness probes are initiated | `30`             |
+| `livenessProbe.periodSeconds`       | How often to perform the probe                                                         | `10`             |
+| `livenessProbe.timeoutSeconds`      | Number of seconds after which the probe times out                                      | `20`             |
+| `livenessProbe.successThreshold`    | Success threshold for liveness probe                                                   | `1`              |
+| `livenessProbe.failureThreshold`    | Minimum consecutive failures for the probe to be considered failed                     | `3`              |
+| `livenessProbe.path`                | The path for the liveness probe                                                        | `/api/v1/health` |
+| `livenessProbe.port`                | The port to use for the probe                                                          | `http`           |
 
 ### Readiness Probe Configurations
 
-| Name                                            | Description                                                                             | Value        |
-| ----------------------------------------------- | --------------------------------------------------------------------------------------- | ------------ |
-| `readinessProbe.enabled`                        | Specifies if the readiness probe is enabled                                             | `true`       |
-| `readinessProbe.initialDelaySeconds`            | Number of seconds after the container has started before readiness probes are initiated | `30`         |
-| `readinessProbe.periodSeconds`                  | How often to perform the probe                                                          | `10`         |
-| `readinessProbe.timeoutSeconds`                 | Number of seconds after which the probe times out                                       | `20`         |
-| `readinessProbe.successThreshold`               | Success threshold for readiness probe                                                   | `1`          |
-| `readinessProbe.failureThreshold`               | Minimum consecutive failures for the probe to be considered failed                      | `6`          |
-| `readinessProbe.path`                           | The path for the readiness probe                                                        | `/v1/health` |
-| `readinessProbe.port`                           | The port to use for the probe                                                           | `http`       |
-| `autoscaling.enabled`                           | Enable autoscaling                                                                      | `true`       |
-| `autoscaling.minReplicas`                       | Minimum number of replicas                                                              | `1`          |
-| `autoscaling.maxReplicas`                       | Minimum number of replicas                                                              | `5`          |
-| `autoscaling.targetCPUUtilizationPercentage`    | Target CPU utilization percentage                                                       | `80`         |
-| `autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage                                                    | `90`         |
+| Name                                            | Description                                                                             | Value            |
+| ----------------------------------------------- | --------------------------------------------------------------------------------------- | ---------------- |
+| `readinessProbe.enabled`                        | Specifies if the readiness probe is enabled                                             | `true`           |
+| `readinessProbe.initialDelaySeconds`            | Number of seconds after the container has started before readiness probes are initiated | `30`             |
+| `readinessProbe.periodSeconds`                  | How often to perform the probe                                                          | `10`             |
+| `readinessProbe.timeoutSeconds`                 | Number of seconds after which the probe times out                                       | `20`             |
+| `readinessProbe.successThreshold`               | Success threshold for readiness probe                                                   | `1`              |
+| `readinessProbe.failureThreshold`               | Minimum consecutive failures for the probe to be considered failed                      | `6`              |
+| `readinessProbe.path`                           | The path for the readiness probe                                                        | `/api/v1/health` |
+| `readinessProbe.port`                           | The port to use for the probe                                                           | `http`           |
+| `autoscaling.enabled`                           | Enable autoscaling                                                                      | `true`           |
+| `autoscaling.minReplicas`                       | Minimum number of replicas                                                              | `1`              |
+| `autoscaling.maxReplicas`                       | Minimum number of replicas                                                              | `5`              |
+| `autoscaling.targetCPUUtilizationPercentage`    | Target CPU utilization percentage                                                       | `80`             |
+| `autoscaling.targetMemoryUtilizationPercentage` | Target Memory utilization percentage                                                    | `90`             |
 
 ### Image Pull secret configuration
 
-| Name                                      | Description                                                   | Value                                  |
-| ----------------------------------------- | ------------------------------------------------------------- | -------------------------------------- |
-| `imagePullSecret.name`                    | Name of the Secret that will be created                       | `docker-secret-cred-tenant-et-service` |
-| `imagePullSecret.key`                     | Specific key inside the secret that will be created           | `.dockerconfigjson`                    |
-| `imagePullSecret.cloudProviderSecretName` | Name of the secret from the cloudprovider (AWS / GCP / AZURE) | `canso-dockerhub-credentials`          |
-| `imagePullSecret.cloudProviderSecretKey`  | Specific key inside the secret from cloud provider            | `dockerhub`                            |
+| Name                                      | Description                                                   | Value                                      |
+| ----------------------------------------- | ------------------------------------------------------------- | ------------------------------------------ |
+| `imagePullSecret.name`                    | Name of the Secret that will be created                       | `docker-secret-cred-canso-dataplane-agent` |
+| `imagePullSecret.key`                     | Specific key inside the secret that will be created           | `.dockerconfigjson`                        |
+| `imagePullSecret.cloudProviderSecretName` | Name of the secret from the cloudprovider (AWS / GCP / AZURE) | `canso-dockerhub-credentials`              |
+| `imagePullSecret.cloudProviderSecretKey`  | Specific key inside the secret from cloud provider            | `dockerhub`                                |

--- a/canso-data-plane/canso-dataplane-agent/README.md
+++ b/canso-data-plane/canso-dataplane-agent/README.md
@@ -3,8 +3,9 @@
 ### deployment configuration
 
 | Name                          | Description                                               | Value    |
-|-------------------------------| --------------------------------------------------------- | -------- |
-| `deployment.image`            | full image identifier                                     | `""`     |
+|-------------------------------|-----------------------------------------------------------|----------|
+| `deployment.image.repository` | Image Repository                                          | `""`     |
+| `deployment.image.tag`        | Image tag                                                 | `""`     |
 | `deployment.image.pullPolicy` | Image pull policy for the deployment                      | `Always` |
 | `deployment.replicas`         | Number of replicas for the canso-fraud-inv-job deployment | `1`      |
 | `podAnnotations`              | POD Annotations                                           | `{}`     |

--- a/canso-data-plane/canso-dataplane-agent/README.md
+++ b/canso-data-plane/canso-dataplane-agent/README.md
@@ -72,7 +72,7 @@
 | --------------------------- | ------------------------------------------------------------------------ | --------------- |
 | `ingress.enabled`           | Enable the ingress                                                       | `false`         |
 | `ingress.host`              | Hostname for the ingress rule (must match the nginx master ingress host) | `""`            |
-| `ingress.path`              | Path exposed externally — routed to the service without rewriting        | `/api/v1/relay` |
+| `ingress.pathPrefix`        | Path prefix exposed externally — routed to the service without rewriting | `/api/v1/relay` |
 | `ingress.pathType`          | Path type for the ingress                                                | `Prefix`        |
 | `ingress.ingressClassName`  | Ingress class name                                                       | `nginx`         |
 | `ingress.clientMaxBodySize` | Maximum allowed request body size                                        | `100m`          |

--- a/canso-data-plane/canso-dataplane-agent/README.md
+++ b/canso-data-plane/canso-dataplane-agent/README.md
@@ -2,14 +2,14 @@
 
 ### deployment configuration
 
-| Name                          | Description                                               | Value    |
-|-------------------------------|-----------------------------------------------------------|----------|
-| `deployment.image.repository` | Image Repository                                          | `""`     |
-| `deployment.image.tag`        | Image tag                                                 | `""`     |
-| `deployment.image.pullPolicy` | Image pull policy for the deployment                      | `Always` |
-| `deployment.replicas`         | Number of replicas for the canso-fraud-inv-job deployment | `1`      |
-| `podAnnotations`              | POD Annotations                                           | `{}`     |
-| `podLabels`                   | POD Labels                                                | `{}`     |
+| Name                          | Description                 | Value                                 |
+| ----------------------------- | --------------------------- | ------------------------------------- |
+| `deployment.image.repository` | repository for the image    | `shaktimaanbot/canso-dataplane-agent` |
+| `deployment.image.pullPolicy` | Pull policy for the image   | `Always`                              |
+| `deployment.image.tag`        | Tag for the image           | `python-3.13-slim-v0.0.1`             |
+| `deployment.replicas`         | replicas for the deployment | `1`                                   |
+| `podAnnotations`              | POD Annotations             | `{}`                                  |
+| `podLabels`                   | POD Labels                  | `{}`                                  |
 
 ### service Service Configuration
 

--- a/canso-data-plane/canso-dataplane-agent/README.md
+++ b/canso-data-plane/canso-dataplane-agent/README.md
@@ -2,13 +2,13 @@
 
 ### deployment configuration
 
-| Name                         | Description                                               | Value    |
-| ---------------------------- | --------------------------------------------------------- | -------- |
-| `deployment.image`           | full image identifier                                     | `""`     |
-| `deployment.imagePullPolicy` | Image pull policy for the deployment                      | `Always` |
-| `deployment.replicas`        | Number of replicas for the canso-fraud-inv-job deployment | `1`      |
-| `podAnnotations`             | POD Annotations                                           | `{}`     |
-| `podLabels`                  | POD Labels                                                | `{}`     |
+| Name                          | Description                                               | Value    |
+|-------------------------------| --------------------------------------------------------- | -------- |
+| `deployment.image`            | full image identifier                                     | `""`     |
+| `deployment.image.pullPolicy` | Image pull policy for the deployment                      | `Always` |
+| `deployment.replicas`         | Number of replicas for the canso-fraud-inv-job deployment | `1`      |
+| `podAnnotations`              | POD Annotations                                           | `{}`     |
+| `podLabels`                   | POD Labels                                                | `{}`     |
 
 ### service Service Configuration
 

--- a/canso-data-plane/canso-dataplane-agent/templates/_helpers.tpl
+++ b/canso-data-plane/canso-dataplane-agent/templates/_helpers.tpl
@@ -1,0 +1,65 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "canso-dataplane-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "canso-dataplane-agent.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "canso-dataplane-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "canso-dataplane-agent.labels" -}}
+helm.sh/chart: {{ include "canso-dataplane-agent.chart" . }}
+{{ include "canso-dataplane-agent.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "canso-dataplane-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "canso-dataplane-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+{{/*
+Create the image path for the passed in image field
+Credits - https://blog.andyserver.com/2021/09/adding-image-digest-references-to-your-helm-charts/
+*/}}
+{{- define "canso-dataplane-agent.image" -}}
+{{- $tag := .tag -}}
+{{- if eq (substr 0 7 $tag) "sha256:" -}}
+{{- printf "%s@%s" .repository $tag -}}
+{{- else -}}
+{{- printf "%s:%s" .repository $tag -}}
+{{- end -}}
+{{- end -}}

--- a/canso-data-plane/canso-dataplane-agent/templates/_helpers.tpl
+++ b/canso-data-plane/canso-dataplane-agent/templates/_helpers.tpl
@@ -49,17 +49,3 @@ Selector labels
 app.kubernetes.io/name: {{ include "canso-dataplane-agent.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
-
-
-{{/*
-Create the image path for the passed in image field
-Credits - https://blog.andyserver.com/2021/09/adding-image-digest-references-to-your-helm-charts/
-*/}}
-{{- define "canso-dataplane-agent.image" -}}
-{{- $tag := .tag -}}
-{{- if eq (substr 0 7 $tag) "sha256:" -}}
-{{- printf "%s@%s" .repository $tag -}}
-{{- else -}}
-{{- printf "%s:%s" .repository $tag -}}
-{{- end -}}
-{{- end -}}

--- a/canso-data-plane/canso-dataplane-agent/templates/deployment.yaml
+++ b/canso-data-plane/canso-dataplane-agent/templates/deployment.yaml
@@ -26,9 +26,9 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.imagePullSecret.name }}
       containers:
-        - name: {{ .Chart.Name }}
-          image: {{ include "canso-dataplane-agent.image" (dict "repository" .Values.deployment.image.repository "tag" (default .Chart.AppVersion .Values.deployment.image.tag)) }}
-          imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
+        - name: {{ .Values.name }}
+          image: "{{ .Values.deployment.image }}"
+          imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/canso-data-plane/canso-dataplane-agent/templates/deployment.yaml
+++ b/canso-data-plane/canso-dataplane-agent/templates/deployment.yaml
@@ -33,8 +33,8 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-            {{- if .Values.livenessProbe.enabled }}
             httpGet:
               path: {{ .Values.livenessProbe.path }}
               port: {{ .Values.livenessProbe.port }}
@@ -43,9 +43,9 @@ spec:
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-            {{- end }}
+          {{- end }}
+          {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
-            {{- if .Values.readinessProbe.enabled }}
             httpGet:
               path: {{ .Values.readinessProbe.path }}
               port: {{ .Values.readinessProbe.port }}
@@ -54,6 +54,6 @@ spec:
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
-            {{- end }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/canso-data-plane/canso-dataplane-agent/templates/deployment.yaml
+++ b/canso-data-plane/canso-dataplane-agent/templates/deployment.yaml
@@ -1,0 +1,59 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "canso-dataplane-agent.fullname" . }}
+  labels:
+    {{- include "canso-dataplane-agent.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.deployment.replicas }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "canso-dataplane-agent.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "canso-dataplane-agent.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret.name }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.deployment.image }}"
+          imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            {{- if .Values.livenessProbe.enabled }}
+            httpGet:
+              path: {{ .Values.livenessProbe.path }}
+              port: {{ .Values.livenessProbe.port }}
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            {{- end }}
+          readinessProbe:
+            {{- if .Values.readinessProbe.enabled }}
+            httpGet:
+              path: {{ .Values.readinessProbe.path }}
+              port: {{ .Values.readinessProbe.port }}
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}

--- a/canso-data-plane/canso-dataplane-agent/templates/deployment.yaml
+++ b/canso-data-plane/canso-dataplane-agent/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - name: {{ .Values.imagePullSecret.name }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.deployment.image }}"
+          image: {{ include "canso-dataplane-agent.image" (dict "repository" .Values.canso-dataplane-agent.deployment.image.repository "tag" (default .Chart.AppVersion .Values.canso-dataplane-agent.deployment.image.tag)) }}
           imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
           ports:
             - name: http

--- a/canso-data-plane/canso-dataplane-agent/templates/deployment.yaml
+++ b/canso-data-plane/canso-dataplane-agent/templates/deployment.yaml
@@ -27,8 +27,8 @@ spec:
         - name: {{ .Values.imagePullSecret.name }}
       containers:
         - name: {{ .Chart.Name }}
-          image: {{ include "canso-dataplane-agent.image" (dict "repository" .Values.canso-dataplane-agent.deployment.image.repository "tag" (default .Chart.AppVersion .Values.canso-dataplane-agent.deployment.image.tag)) }}
-          imagePullPolicy: {{ .Values.deployment.imagePullPolicy }}
+          image: {{ include "canso-dataplane-agent.image" (dict "repository" .Values.deployment.image.repository "tag" (default .Chart.AppVersion .Values.deployment.image.tag)) }}
+          imagePullPolicy: {{ .Values.deployment.image.pullPolicy }}
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}

--- a/canso-data-plane/canso-dataplane-agent/templates/deployment.yaml
+++ b/canso-data-plane/canso-dataplane-agent/templates/deployment.yaml
@@ -33,6 +33,13 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- if .Values.deployment.env }}
+          env:
+            {{- range $key, $value := .Values.deployment.env }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+          {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
             httpGet:

--- a/canso-data-plane/canso-dataplane-agent/templates/hpa.yaml
+++ b/canso-data-plane/canso-dataplane-agent/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "canso-dataplane-agent.fullname" . }}
+  labels:
+    {{- include "canso-dataplane-agent.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "canso-dataplane-agent.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/canso-data-plane/canso-dataplane-agent/templates/image-pull-secret.yaml
+++ b/canso-data-plane/canso-dataplane-agent/templates/image-pull-secret.yaml
@@ -1,0 +1,18 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ .Values.imagePullSecret.name }}-es
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: secretstore-by-role
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Values.imagePullSecret.name }}
+    template:
+      type: kubernetes.io/dockerconfigjson 
+  data:
+  - secretKey: {{ .Values.imagePullSecret.key }} 
+    remoteRef:
+      key: {{ .Values.imagePullSecret.cloudProviderSecretName }} 
+      property: {{ .Values.imagePullSecret.cloudProviderSecretKey }}

--- a/canso-data-plane/canso-dataplane-agent/templates/ingress.yaml
+++ b/canso-data-plane/canso-dataplane-agent/templates/ingress.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "canso-dataplane-agent.fullname" . }}-ing
+  labels:
+    {{- include "canso-dataplane-agent.labels" . | nindent 4 }}
+  annotations:
+    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+spec:
+  ingressClassName: {{ .Values.ingress.ingressClassName }}
+  rules:
+    - host: {{ .Values.ingress.host }}
+      http:
+        paths:
+          - path: {{ .Values.ingress.path }}
+            pathType: {{ .Values.ingress.pathType }}
+            backend:
+              service:
+                name: canso-dataplane-agent
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/canso-data-plane/canso-dataplane-agent/templates/ingress.yaml
+++ b/canso-data-plane/canso-dataplane-agent/templates/ingress.yaml
@@ -6,7 +6,11 @@ metadata:
   labels:
     {{- include "canso-dataplane-agent.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    nginx.org/mergeable-ingress-type: minion
+    nginx.org/client-max-body-size: {{ .Values.ingress.clientMaxBodySize | quote }}
+    {{- with .Values.ingress.extraAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.ingress.ingressClassName }}
   rules:

--- a/canso-data-plane/canso-dataplane-agent/templates/ingress.yaml
+++ b/canso-data-plane/canso-dataplane-agent/templates/ingress.yaml
@@ -17,7 +17,7 @@ spec:
     - host: {{ .Values.ingress.host }}
       http:
         paths:
-          - path: {{ .Values.ingress.path }}
+          - path: {{ .Values.ingress.pathPrefix }}
             pathType: {{ .Values.ingress.pathType }}
             backend:
               service:

--- a/canso-data-plane/canso-dataplane-agent/templates/ingress.yaml
+++ b/canso-data-plane/canso-dataplane-agent/templates/ingress.yaml
@@ -21,7 +21,7 @@ spec:
             pathType: {{ .Values.ingress.pathType }}
             backend:
               service:
-                name: canso-dataplane-agent
+                name: {{ include "canso-dataplane-agent.fullname" . }}
                 port:
                   number: {{ .Values.service.port }}
 {{- end }}

--- a/canso-data-plane/canso-dataplane-agent/templates/networkpolicy.yaml
+++ b/canso-data-plane/canso-dataplane-agent/templates/networkpolicy.yaml
@@ -13,10 +13,11 @@ spec:
     - Ingress
     - Egress
   ingress:
-    # Accept traffic only from the ALB (which routes via VPC-internal IPs when target-type: ip)
+    # Accept traffic only from the nginx ingress controller pods
     - from:
-        - ipBlock:
-            cidr: {{ .Values.networkPolicy.ingressVpcCidr }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Values.networkPolicy.nginxIngressNamespace }}
       ports:
         - protocol: TCP
           port: {{ .Values.service.port }}

--- a/canso-data-plane/canso-dataplane-agent/templates/networkpolicy.yaml
+++ b/canso-data-plane/canso-dataplane-agent/templates/networkpolicy.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "canso-dataplane-agent.fullname" . }}-netpol
+  labels:
+    {{- include "canso-dataplane-agent.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "canso-dataplane-agent.selectorLabels" . | nindent 6 }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    # Accept traffic only from the ALB (which routes via VPC-internal IPs when target-type: ip)
+    - from:
+        - ipBlock:
+            cidr: {{ .Values.networkPolicy.ingressVpcCidr }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.service.port }}
+  egress:
+    # DNS resolution
+    - ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    # Upstream cluster services this agent proxies to
+    {{- range .Values.networkPolicy.egressPorts }}
+    - ports:
+        - protocol: TCP
+          port: {{ . }}
+    {{- end }}
+{{- end }}

--- a/canso-data-plane/canso-dataplane-agent/templates/service.yaml
+++ b/canso-data-plane/canso-dataplane-agent/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: canso-dataplane-agent
+  labels:
+    {{- include "canso-dataplane-agent.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "canso-dataplane-agent.selectorLabels" . | nindent 4 }}

--- a/canso-data-plane/canso-dataplane-agent/values.yaml
+++ b/canso-data-plane/canso-dataplane-agent/values.yaml
@@ -4,16 +4,12 @@
 
 ## @section deployment configuration
 deployment:
-  image:
-    ## @param deployment.image.repository repository for the image
-    ##
-    repository: shaktimaanbot/canso-dataplane-agent
-    ## @param deployment.image.pullPolicy Pull policy for the image
-    ##
-    pullPolicy: Always
-    ## @param deployment.image.tag Tag for the image
-    ##
-    tag: "python-3.13-slim-v0.0.1"
+  ## @param deployment.image Full image identifier (repository:tag)
+  ##
+  image: "shaktimaanbot/canso-dataplane-agent:python-3.13-slim-v0.0.1"
+  ## @param deployment.imagePullPolicy Pull policy for the image
+  ##
+  imagePullPolicy: Always
   ## @param deployment.replicas replicas for the deployment
   replicas: 1
   ## @skip deployment.env Environment variables for the container
@@ -28,6 +24,10 @@ deployment:
     HTTP_MAX_CONNECTIONS: "100"
     HTTP_MAX_KEEPALIVE_CONNECTIONS: "20"
     HTTP_KEEPALIVE_EXPIRY: "30.0"
+
+## @param name Name of the service
+##
+name: canso-dataplane-agent
 
 ## @skip nameOverride Name override
 nameOverride: ""

--- a/canso-data-plane/canso-dataplane-agent/values.yaml
+++ b/canso-data-plane/canso-dataplane-agent/values.yaml
@@ -5,12 +5,17 @@
 ## @section deployment configuration
 deployment:
   ## @param deployment.image full image identifier
-  image: ""
-  ## @param deployment.imagePullPolicy Image pull policy for the deployment
-  ##
-  imagePullPolicy: Always
-  ## @param deployment.replicas Number of replicas for the canso-fraud-inv-job deployment
-  ##
+  image:
+    ## @param canso-dataplane-agent.deployment.image.repository repository for the image
+    ##
+    repository: shaktimaanbot/canso-dataplane-agent
+    ## @param canso-dataplane-agent.deployment.image.pullPolicy Pull policy for the image
+    ##
+    pullPolicy: Always
+    ## @param canso-dataplane-agent.deployment.image.tag Tag for the image
+    ##
+    tag: ""
+  
   replicas: 1
 
 ## @skip nameOverride Name override

--- a/canso-data-plane/canso-dataplane-agent/values.yaml
+++ b/canso-data-plane/canso-dataplane-agent/values.yaml
@@ -15,7 +15,7 @@ deployment:
     ## @param deployment.image.tag Tag for the image
     ##
     tag: "python-3.13-slim-v0.0.1"
-  
+  ## @param deployment.replicas replicas for the deployment
   replicas: 1
 
 ## @skip nameOverride Name override

--- a/canso-data-plane/canso-dataplane-agent/values.yaml
+++ b/canso-data-plane/canso-dataplane-agent/values.yaml
@@ -156,9 +156,9 @@ ingress:
   ## @param ingress.host Hostname for the ingress rule (must match the nginx master ingress host)
   ##
   host: ""
-  ## @param ingress.path Path exposed externally — routed to the service without rewriting
+  ## @param ingress.pathPrefix Path prefix exposed externally — routed to the service without rewriting
   ##
-  path: /api/v1/relay
+  pathPrefix: /api/v1/relay
   ## @param ingress.pathType Path type for the ingress
   ##
   pathType: Prefix

--- a/canso-data-plane/canso-dataplane-agent/values.yaml
+++ b/canso-data-plane/canso-dataplane-agent/values.yaml
@@ -1,0 +1,148 @@
+# Default values for canso-tenant-et-service.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+## @section deployment configuration
+deployment:
+  ## @param deployment.image full image identifier
+  image: ""
+  ## @param deployment.imagePullPolicy Image pull policy for the deployment
+  ##
+  imagePullPolicy: Always
+  ## @param deployment.replicas Number of replicas for the canso-fraud-inv-job deployment
+  ##
+  replicas: 1
+
+## @skip nameOverride Name override
+nameOverride: ""
+## @skip fullnameOverride Full name override
+fullnameOverride: ""
+
+
+## @param podAnnotations POD Annotations
+##
+podAnnotations: {}
+## @param podLabels POD Labels
+##
+podLabels: {}
+
+
+## @section service Service Configuration
+##
+service:
+  ## @param service.type Service Type (ClusterIP, NodePort, and LoadBalancer)
+  ##
+  type: ClusterIP
+  ## @param service.port Port used by clients to access the service
+  ##
+  port: 8090
+
+## @section resources Resource Configuration
+##
+resources:
+  ## @section resources.request Resource request Configuration
+  ##
+  requests:
+    ## @param resources.requests.cpu Resource request  cpu Configuration
+    ##
+    cpu: 400m
+    ## @param resources.requests.memory Resource request memory Configuration
+    ##
+    memory: 384Mi
+  ## @section resources.limits Resource limits Configuration
+  ##
+  limits:
+    ## @param resources.limits.cpu Resource limits cpu Configuration
+    ##
+    cpu: 750m
+    ## @param resources.limits.memory Resource limits memory Configuration
+    ##
+    memory: 768Mi
+  
+## @section Liveness Probe Configurations
+## @param livenessProbe.enabled Specifies if the liveness probe is enabled
+##
+livenessProbe:
+  ## @param livenessProbe.enabled Specifies if the liveness probe is enabled
+  ##
+  enabled: true
+  ## @param livenessProbe.initialDelaySeconds Number of seconds after the container has started before liveness probes are initiated
+  ##
+  initialDelaySeconds: 30
+  ## @param livenessProbe.periodSeconds How often to perform the probe
+  ##
+  periodSeconds: 10
+  ## @param livenessProbe.timeoutSeconds Number of seconds after which the probe times out
+  ##
+  timeoutSeconds: 20
+  ## @param livenessProbe.successThreshold Success threshold for liveness probe
+  ##
+  successThreshold: 1
+  ## @param livenessProbe.failureThreshold Minimum consecutive failures for the probe to be considered failed
+  ##
+  failureThreshold: 3
+  ## @param livenessProbe.path  The path for the liveness probe
+  ##
+  path: /api/v1/health
+  ## @param livenessProbe.port  The port to use for the probe
+  ##
+  port: http
+
+## @section Readiness Probe Configurations
+readinessProbe:
+  ## @param readinessProbe.enabled  Specifies if the readiness probe is enabled
+  ##
+  enabled: true
+  ## @param readinessProbe.initialDelaySeconds  Number of seconds after the container has started before readiness probes are initiated
+  ##
+  initialDelaySeconds: 30
+  ## @param readinessProbe.periodSeconds  How often to perform the probe
+  ##
+  periodSeconds: 10
+  ## @param readinessProbe.timeoutSeconds  Number of seconds after which the probe times out
+  ##
+  timeoutSeconds: 20
+  ## @param readinessProbe.successThreshold Success threshold for readiness probe
+  ##
+  successThreshold: 1
+  ## @param readinessProbe.failureThreshold  Minimum consecutive failures for the probe to be considered failed
+  ##
+  failureThreshold: 6
+  ## @param readinessProbe.path  The path for the readiness probe
+  ##
+  path: /api/v1/health
+  ## @param readinessProbe.port  The port to use for the probe
+  ##
+  port: http
+
+autoscaling:
+  ## @param autoscaling.enabled Enable autoscaling
+  ##
+  enabled: true
+  ## @param autoscaling.minReplicas Minimum number of replicas
+  ##
+  minReplicas: 1
+  ## @param autoscaling.maxReplicas Minimum number of replicas
+  ##
+  maxReplicas: 5
+  ## @param autoscaling.targetCPUUtilizationPercentage Target CPU utilization percentage
+  ##
+  targetCPUUtilizationPercentage: 80
+  ## @param autoscaling.targetMemoryUtilizationPercentage Target Memory utilization percentage
+  ##
+  targetMemoryUtilizationPercentage: 90
+
+## @section Image Pull secret configuration
+imagePullSecret:
+  ## @param imagePullSecret.name Name of the Secret that will be created
+  ##
+  name: docker-secret-cred-canso-dataplane-agent
+  ## @param imagePullSecret.key Specific key inside the secret that will be created
+  ##
+  key: .dockerconfigjson
+  ## @param imagePullSecret.cloudProviderSecretName Name of the secret from the cloudprovider (AWS / GCP / AZURE)
+  ##
+  cloudProviderSecretName: canso-dockerhub-credentials
+  ## @param imagePullSecret.cloudProviderSecretKey Specific key inside the secret from cloud provider
+  ##
+  cloudProviderSecretKey: dockerhub

--- a/canso-data-plane/canso-dataplane-agent/values.yaml
+++ b/canso-data-plane/canso-dataplane-agent/values.yaml
@@ -136,6 +136,55 @@ autoscaling:
   ##
   targetMemoryUtilizationPercentage: 90
 
+## @section Ingress Configuration
+##
+ingress:
+  ## @param ingress.enabled Enable the ingress
+  ##
+  enabled: false
+  ## @param ingress.host Hostname for the ingress rule
+  ##
+  host: "" # example: dataplane-agent.tenant.company.com
+  ## @param ingress.path Path for path-based routing
+  ##
+  path: /
+  ## @param ingress.pathType Path type for the ingress
+  ##
+  pathType: Prefix
+  ## @param ingress.ingressClassName Ingress class name
+  ##
+  ingressClassName: alb
+  ## @skip ingress.annotations Annotations for the AWS ALB ingress controller
+  ##
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80},{"HTTPS": 443}]'
+    alb.ingress.kubernetes.io/ssl-redirect: '443'
+    alb.ingress.kubernetes.io/certificate-arn: '' # ACM certificate ARN for TLS
+    alb.ingress.kubernetes.io/group.name: '' # ALB group to share a single LB across services
+    alb.ingress.kubernetes.io/healthcheck-path: '/api/v1/health'
+    alb.ingress.kubernetes.io/healthcheck-interval-seconds: '30'
+    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '10'
+    alb.ingress.kubernetes.io/tags: ''
+
+## @section Network Policy Configuration
+##
+networkPolicy:
+  ## @param networkPolicy.enabled Enable the network policy
+  ##
+  enabled: false
+  ## @param networkPolicy.ingressVpcCidr VPC CIDR from which ALB sends traffic to pods (target-type: ip)
+  ##
+  ingressVpcCidr: "10.0.0.0/8"
+  ## @param networkPolicy.egressPorts List of TCP ports the agent is allowed to reach on upstream cluster services
+  ##
+  egressPorts:
+    - 80
+    - 443
+    - 8080
+    - 8090
+
 ## @section Image Pull secret configuration
 imagePullSecret:
   ## @param imagePullSecret.name Name of the Secret that will be created

--- a/canso-data-plane/canso-dataplane-agent/values.yaml
+++ b/canso-data-plane/canso-dataplane-agent/values.yaml
@@ -16,6 +16,18 @@ deployment:
     tag: "python-3.13-slim-v0.0.1"
   ## @param deployment.replicas replicas for the deployment
   replicas: 1
+  ## @skip deployment.env Environment variables for the container
+  env:
+    HOST: "0.0.0.0"
+    PORT: "8090"
+    WORKERS: "4"
+    HTTP_CONNECT_TIMEOUT: "10.0"
+    HTTP_READ_TIMEOUT: "120.0"
+    HTTP_WRITE_TIMEOUT: "120.0"
+    HTTP_POOL_TIMEOUT: "5.0"
+    HTTP_MAX_CONNECTIONS: "100"
+    HTTP_MAX_KEEPALIVE_CONNECTIONS: "20"
+    HTTP_KEEPALIVE_EXPIRY: "30.0"
 
 ## @skip nameOverride Name override
 nameOverride: ""
@@ -64,7 +76,6 @@ resources:
     memory: 768Mi
   
 ## @section Liveness Probe Configurations
-## @param livenessProbe.enabled Specifies if the liveness probe is enabled
 ##
 livenessProbe:
   ## @param livenessProbe.enabled Specifies if the liveness probe is enabled
@@ -177,8 +188,7 @@ networkPolicy:
   ## @param networkPolicy.ingressVpcCidr VPC CIDR from which ALB sends traffic to pods (target-type: ip)
   ##
   ingressVpcCidr: "10.0.0.0/8"
-  ## @param networkPolicy.egressPorts List of TCP ports the agent is allowed to reach on upstream cluster services
-  ##
+  ## @skip networkPolicy.egressPorts List of TCP ports the agent is allowed to reach on upstream cluster services
   egressPorts:
     - 80
     - 443

--- a/canso-data-plane/canso-dataplane-agent/values.yaml
+++ b/canso-data-plane/canso-dataplane-agent/values.yaml
@@ -1,4 +1,4 @@
-# Default values for canso-tenant-et-service.
+# Default values for canso-dataplane-agent.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
@@ -153,47 +153,36 @@ ingress:
   ## @param ingress.enabled Enable the ingress
   ##
   enabled: false
-  ## @param ingress.host Hostname for the ingress rule
+  ## @param ingress.host Hostname for the ingress rule (must match the nginx master ingress host)
   ##
-  host: "" # example: dataplane-agent.tenant.company.com
-  ## @param ingress.path Path for path-based routing
+  host: ""
+  ## @param ingress.path Path exposed externally — routed to the service without rewriting
   ##
-  path: /
+  path: /api/v1/relay
   ## @param ingress.pathType Path type for the ingress
   ##
   pathType: Prefix
   ## @param ingress.ingressClassName Ingress class name
   ##
-  ingressClassName: alb
-  ## @skip ingress.annotations Annotations for the AWS ALB ingress controller
+  ingressClassName: nginx
+  ## @param ingress.clientMaxBodySize Maximum allowed request body size
   ##
-  annotations:
-    alb.ingress.kubernetes.io/scheme: internet-facing
-    alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80},{"HTTPS": 443}]'
-    alb.ingress.kubernetes.io/ssl-redirect: '443'
-    alb.ingress.kubernetes.io/certificate-arn: '' # ACM certificate ARN for TLS
-    alb.ingress.kubernetes.io/group.name: '' # ALB group to share a single LB across services
-    alb.ingress.kubernetes.io/healthcheck-path: '/api/v1/health'
-    alb.ingress.kubernetes.io/healthcheck-interval-seconds: '30'
-    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: '10'
-    alb.ingress.kubernetes.io/tags: ''
+  clientMaxBodySize: "100m"
+  ## @skip ingress.extraAnnotations Additional nginx annotations to merge in
+  extraAnnotations: {}
 
 ## @section Network Policy Configuration
 ##
 networkPolicy:
   ## @param networkPolicy.enabled Enable the network policy
   ##
-  enabled: false
-  ## @param networkPolicy.ingressVpcCidr VPC CIDR from which ALB sends traffic to pods (target-type: ip)
+  enabled: true
+  ## @param networkPolicy.nginxIngressNamespace Namespace where the nginx ingress controller runs
   ##
-  ingressVpcCidr: "10.0.0.0/8"
+  nginxIngressNamespace: "nginx-ingress"
   ## @skip networkPolicy.egressPorts List of TCP ports the agent is allowed to reach on upstream cluster services
   egressPorts:
-    - 80
-    - 443
-    - 8080
-    - 8090
+    - 8085
 
 ## @section Image Pull secret configuration
 imagePullSecret:

--- a/canso-data-plane/canso-dataplane-agent/values.yaml
+++ b/canso-data-plane/canso-dataplane-agent/values.yaml
@@ -4,7 +4,6 @@
 
 ## @section deployment configuration
 deployment:
-  ## @param deployment.image full image identifier
   image:
     ## @param deployment.image.repository repository for the image
     ##

--- a/canso-data-plane/canso-dataplane-agent/values.yaml
+++ b/canso-data-plane/canso-dataplane-agent/values.yaml
@@ -6,15 +6,15 @@
 deployment:
   ## @param deployment.image full image identifier
   image:
-    ## @param canso-dataplane-agent.deployment.image.repository repository for the image
+    ## @param deployment.image.repository repository for the image
     ##
     repository: shaktimaanbot/canso-dataplane-agent
-    ## @param canso-dataplane-agent.deployment.image.pullPolicy Pull policy for the image
+    ## @param deployment.image.pullPolicy Pull policy for the image
     ##
     pullPolicy: Always
-    ## @param canso-dataplane-agent.deployment.image.tag Tag for the image
+    ## @param deployment.image.tag Tag for the image
     ##
-    tag: ""
+    tag: "python-3.13-slim-v0.0.1"
   
   replicas: 1
 


### PR DESCRIPTION
### 🔗  Linked Issue

NA


## 📌 Context and Description

This PR adds Helm chart for deploying [canso-dataplane-agent](https://github.com/Yugen-ai/canso-dataplane-agent)

## 🧐 Testing

<details open>
<summary>Local testing </summary>

### Local run with Helm template command

#### Command

```bash
helm template canso-dataplane-agent
```

#### Command output

<img width="2128" height="1351" alt="image" src="https://github.com/user-attachments/assets/51c06a34-bede-439d-8f6d-ec374c96dd78" />


</details>

## 📚 Notes

NA