### PR TITLE
Dplane otelcollector: Remmove profile configuration

### DIFF
--- a/canso-data-plane/canso-dplane-otelcollector/Chart.yaml
+++ b/canso-data-plane/canso-dplane-otelcollector/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: canso-dplane-otelcollector
 description: A Helm chart for deploying otelcollector in data plane
 type: application
-version: 0.0.6
+version: 0.0.7
 appVersion: "0.0.1"
 
 dependencies:

--- a/canso-data-plane/canso-dplane-otelcollector/values.yaml
+++ b/canso-data-plane/canso-dplane-otelcollector/values.yaml
@@ -100,21 +100,6 @@ opentelemetry-collector:
         routing:
           exchange: "${env:RABBITMQ_EXCHANGE}"
           routing_key: "otlp.logs"
-
-      rabbitmq/profiles:
-        connection:
-          endpoint: "${env:RABBITMQ_URL}"
-          auth:
-            plain:
-              username: "${env:RABBITMQ_USERNAME}"
-              password: "${env:RABBITMQ_PASSWORD}"
-          tls:
-            insecure: false 
-            insecure_skip_verify: true
-        encoding_extension: otlp_encoding
-        routing:
-          exchange: "${env:RABBITMQ_EXCHANGE}"
-          routing_key: "otlp.profiles"
       
     service:
       extensions:
@@ -132,7 +117,3 @@ opentelemetry-collector:
           receivers: [otlp]
           processors: [batch]
           exporters: [rabbitmq/logs]
-        profiles:
-          receivers: [otlp]
-          processors: [batch]
-          exporters: [rabbitmq/profiles]


### PR DESCRIPTION
Preventing the following error:
```
Error: invalid configuration: service::pipelines: pipeline "profiles": profiling signal support is at alpha level, gated under the "service.profilesSupport" feature gate
```